### PR TITLE
Fix anchors in documentation page

### DIFF
--- a/src/documentation.html
+++ b/src/documentation.html
@@ -55,8 +55,13 @@
         ToC += "</ul>";
 
         $("#navbar-nav").prepend(ToC);
+
+        setTimeout(function () {
+          var hash = window.location.hash;
+          window.location.hash = "";
+          window.location.hash = hash;
+        });
       });
-      
     });
   </script>
 </head>


### PR DESCRIPTION
Hashes in URL were not working properly on the documentation page: it was not jumping to the anchor. Due to the fact that we load asynchronously the content of this page.