### PR TITLE
Fix bin path and grant type option

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -16,8 +16,8 @@ To create a new pair of client id / secret, use the following command:
 
 ```bash
 php app/console pim:oauth-server:create-client \
-    --grant-type="password" \
-    --grant-type="refresh_token"
+    --grant_type="password" \
+    --grant_type="refresh_token"
 ```
 
 You will get something like:

--- a/src/getting-started-admin.html
+++ b/src/getting-started-admin.html
@@ -122,9 +122,9 @@
                     <div class="col-xs-12">
                       <p>Having a user with a role giving access to the Web API is not enough to make requests via the Web API. Peter will ask you for OAuth client id and secret so as he can be authenticated.</p>
                       <p>Client is and secret are generated with the following command line.</p>
-                      <pre class="hljs"><code>php bin/console pim:oauth-server:create-client \
-    --grant-type=<span class="hljs-string">"password"</span> \
-    --grant-type=<span class="hljs-string">"refresh_token"</span></code></pre>
+                      <pre class="hljs"><code>php app/console pim:oauth-server:create-client \
+    --grant_type=<span class="hljs-string">"password"</span> \
+    --grant_type=<span class="hljs-string">"refresh_token"</span></code></pre>
                       <p>You will get something like:</p>
                       <pre class="hljs"><code>A new client has been added:
 client_id: 4gm4rnoizp8gskgkk080ssoo80040g44ksowwgw844k44sc00s


### PR DESCRIPTION
Playing with the web api i discovered following typos, in Akeneo PIM, "console" command is available in "app" and not in "bin" and there is also a typo in the "grant type" option, "grant_type" and not "grant-type".

```
nico@nico-laptop:~/git/pim-ce-17-odm$ php app/console pim:oauth-server:create-client     --grant-type="password"     --grant-type="refresh_token"

                                             
  [RuntimeException]                         
  The "--grant-type" option does not exist.  

pim:oauth-server:create-client [--redirect_uri REDIRECT_URI] [--grant_type GRANT_TYPE] [--label LABEL]

nico@nico-laptop:~/git/pim-ce-17-odm$ php app/console pim:oauth-server:create-client --grant_type="password" --grant_type="refresh_token"
A new client has been added.
client_id: 1_3bza1888wji8osko8wkw0sgwowkwkkcwcwoow44k8g4oswggko
secret: 1dtnrs3jhef4wws8ksg0888wosg8ossssg80kwccowwksw0kcc

```