### PR TITLE
Fix indentation of highlighted blocks in documentation pages

### DIFF
--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -50,7 +50,7 @@
 </nav>
 
 <div id="mainContent">
-    {{> @partial-block }}
+{{> @partial-block }}
 </div>
 
 <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>


### PR DESCRIPTION
In documentation pages, hightlighted code blocks were not well indented. This fixes it.