### PR TITLE
Fix missing endpoints in the catalog structure access table for the authorization

### DIFF
--- a/content/security.md
+++ b/content/security.md
@@ -220,9 +220,9 @@ You can tune more finely this permission by restricting or allowing the access t
 | List attribute options | GET on `/attributes/{attribute_code}/options` and on `/attributes/{attribute_code}/options/{attribute_option_code}` |
 | List channels | GET on `/channels` |
 | List locales | GET on `/locales` |
-| Create and update categories | POST and PATCH on `/categories/{category_code}` |
-| Create and update families | POST and PATCH on `/families/{family_code}` |
-| Create and update attributes | POST and PATCH on `/attributes/{attribute_code}` |
+| Create and update categories | POST and PATCH on `/categories/{category_code}` <br/> PATCH on `/categories` |
+| Create and update families | POST and PATCH on `/families/{family_code}` <br/> PATCH on `/families` |
+| Create and update attributes | POST and PATCH on `/attributes/{attribute_code}` <br/> PATCH on `/attributes`|
 | Create and update attribute options | POST and PATCH on `/attributes/{attribute_code}/options/{attribute_option_code}` |
 
 :::warning

--- a/tasks/documentation.js
+++ b/tasks/documentation.js
@@ -46,7 +46,7 @@ function highlight(str, lang) {
 
 gulp.task('documentation', ['clean-dist'],function (){
       var optionsMd = {
-          html: false,
+          html: true,
           xhtmlOut: true,
           typographer: false,
           linkify: false,


### PR DESCRIPTION
Endpoints about patch list on categories, families, and attributes were missing in the table "Catalog structure access".

To allows carriage return in a table, we have to accept `html` in the markdown.