### PR TITLE
[PIM-6291] Add attribute_as_image [DO NOT MERGE NOW]

### DIFF
--- a/content/akeneo-web-api.yaml
+++ b/content/akeneo-web-api.yaml
@@ -1923,8 +1923,9 @@ definitions:
         x-validation-rules: "&bull; It is equal to an existing attribute code &#10;&bull; This attribute code is in the array of the property `attributes` &#10;&bull; The type of this attribute is either `pim_catalog_identifier` or `pim_catalog_text`"
       attribute_as_image:
         type: string
-        description: Attribute code used as image (can be null)
+        description: Attribute code used as the main picture in the user interface
         x-validation-rules: "&bull; It is equal to an existing attribute code &#10;&bull; This attribute code is in the array of the property `attributes` &#10;&bull; The type of this attribute is `pim_catalog_image`"
+        default: "null"
       attributes:
         type: array
         description: Attributes codes that compose the family

--- a/content/akeneo-web-api.yaml
+++ b/content/akeneo-web-api.yaml
@@ -694,8 +694,9 @@ paths:
                     }
                   },
                   "code": "tshirt",
-                  "attributes": ["sku", "name", "description", "price", "size", "color"],
+                  "attributes": ["sku", "name", "description", "price", "size", "color", "picture"],
                   "attribute_as_label": "name",
+                  "attribute_as_image": "picture",
                   "attribute_requirements": {
                     "ecommerce": ["sku", "name", "description", "price", "size", "color"],
                     "tablet": ["sku", "name", "description", "price"]
@@ -712,8 +713,9 @@ paths:
                     }
                   },
                   "code": "caps",
-                  "attributes": ["sku", "name", "description", "price", "color"],
+                  "attributes": ["sku", "name", "description", "price", "color", "picture"],
                   "attribute_as_label": "name",
+                  "attribute_as_image": "picture",
                   "attribute_requirements": {
                     "ecommerce": ["sku", "name", "description", "price", "color"],
                     "tablet": ["sku", "name", "description", "price"]
@@ -1919,6 +1921,10 @@ definitions:
         type: string
         description: Attribute code used as label
         x-validation-rules: "&bull; It is equal to an existing attribute code &#10;&bull; This attribute code is in the array of the property `attributes` &#10;&bull; The type of this attribute is either `pim_catalog_identifier` or `pim_catalog_text`"
+      attribute_as_image:
+        type: string
+        description: Attribute code used as image (can be null)
+        x-validation-rules: "&bull; It is equal to an existing attribute code &#10;&bull; This attribute code is in the array of the property `attributes` &#10;&bull; The type of this attribute is `pim_catalog_image`"
       attributes:
         type: array
         description: Attributes codes that compose the family
@@ -1947,8 +1953,9 @@ definitions:
             description: Family label for the locale `localeCode`
     example: {
       "code": "caps",
-      "attributes": ["sku", "name", "description", "price", "color"],
+      "attributes": ["sku", "name", "description", "price", "color", "picture"],
       "attribute_as_label": "name",
+      "attribute_as_image": "picture",
       "attribute_requirements": {
         "ecommerce": ["sku", "name", "description", "price", "color"],
         "tablet": ["sku", "name", "description", "price"]

--- a/content/resources.md
+++ b/content/resources.md
@@ -325,6 +325,7 @@ Below is the JSON standard format representing this family.
     "weight"
   ],
   "attribute_as_label": "name",
+  "attribute_as_image": "picture",
   "attribute_requirements": {
     "ecommerce": [
       "description",


### PR DESCRIPTION
This PR add "attribute_as_image" field for families.
Can be merged when:
- There is versionning in this repository (this is not part of v1.0)
- This PR is merged on master: https://github.com/pierallard/pim-community-dev/pull/11