### PR TITLE
Fix nav width in the doc page

### DIFF
--- a/styles/nav.less
+++ b/styles/nav.less
@@ -65,6 +65,10 @@
 // Table of content
 ul.nav.nav-stacked{
   padding: 80px 20px 0 0;
+  width: 285px;
+  @media (max-width: @screen-md-max) {
+    width: 200px;
+  }
   li{
     a {
       padding: 3px 10px;
@@ -138,8 +142,4 @@ ul.nav ul {
       background-color: @gray-lighter;
     }
   }
-}
-
-ul.nav.nav-stacked {
-  min-width: 285px;
 }


### PR DESCRIPTION
At certain screen width, navigation menu of the documentation page was hidden behind the main content.
Giving it a fixed width depending on the screen width seems to fix the issue.

Before:
![screen shot 2017-04-14 at 16 41 43](https://cloud.githubusercontent.com/assets/25225430/25046387/7fb89c22-2131-11e7-8110-6177d423337d.png)

After:
![screen shot 2017-04-14 at 16 41 13](https://cloud.githubusercontent.com/assets/25225430/25046398/88c1b308-2131-11e7-92b1-b0ccc0f6e168.png)
