### PR TITLE
Add multiple redirections to the product values format

### DIFF
--- a/content/update.md
+++ b/content/update.md
@@ -378,6 +378,10 @@ You want to add the `description` of the product `boots-4846` for the `en_US` lo
 }
 ```
 
+::: info 
+Wondering how to format the `data` property in these product values? In fact, it depends on the attribute type. [More details right here!](/documentation/resources.html#product-values)
+:::
+
 ### Modify a product value
 
 #### First example
@@ -518,6 +522,10 @@ You want to add the `name` of the product `boots-4846` for the `fr_FR` locale bu
 }
 ```
 
+::: info 
+Wondering how to format the `data` property in these product values? In fact, it depends on the attribute type. [More details right here!](/documentation/resources.html#product-values)
+:::
+
 ### Erase a product value
 You want to erase the `name` of the product `boots-4846` for the `en_US` locale.
 
@@ -582,3 +590,7 @@ You want to erase the `name` of the product `boots-4846` for the `en_US` locale.
 }
 ```
 
+
+::: info 
+Wondering how to format the `data` property in these product values? In fact, it depends on the attribute type. [More details right here!](/documentation/resources.html#product-values)
+:::


### PR DESCRIPTION
The documentation about the product values format is a little bit hidden in the Resources section.

I added some redirections to this doc into the Update section, where product values are manipulated and users may ask themselves about this format.

I duplicated the redirections for each use case: Add, modify and erase a product value so that no one miss it.