### PR TITLE
Fix error in the api doc about media and code HTTP 201 and 204

### DIFF
--- a/content/akeneo-web-api.yaml
+++ b/content/akeneo-web-api.yaml
@@ -2393,12 +2393,16 @@ responses:
   Created:
     description: Created
     x-details: Means that the creation was successful
+    headers:
+      Location:
+        description: URI of the created resource
+        type: string
   NoContent:
     description: No content to return
     x-details: Means that the update was successful
     headers:
       Location:
-        description: URI of the resource
+        description: URI of the updated resource
         type: string
   400Error:
     description: Bad request

--- a/content/akeneo-web-api.yaml
+++ b/content/akeneo-web-api.yaml
@@ -380,8 +380,6 @@ paths:
           $ref: "#/responses/401Error"
         403:
           $ref: "#/responses/403Error"
-        404:
-          $ref: "#/responses/404Error"
         415:
           $ref: "#/responses/415Error"
         422:
@@ -640,8 +638,6 @@ paths:
           $ref: "#/responses/401Error"
         403:
           $ref: "#/responses/403Error"
-        404:
-          $ref: "#/responses/404Error"
         415:
           $ref: "#/responses/415Error"
         422:
@@ -848,8 +844,6 @@ paths:
           $ref: "#/responses/401Error"
         403:
           $ref: "#/responses/403Error"
-        404:
-          $ref: "#/responses/404Error"
         415:
           $ref: "#/responses/415Error"
         422:
@@ -1092,8 +1086,6 @@ paths:
           $ref: "#/responses/401Error"
         403:
           $ref: "#/responses/403Error"
-        404:
-          $ref: "#/responses/404Error"
         415:
           $ref: "#/responses/415Error"
         422:
@@ -1270,8 +1262,6 @@ paths:
           $ref: "#/responses/401Error"
         403:
           $ref: "#/responses/403Error"
-        404:
-          $ref: "#/responses/404Error"
         415:
           $ref: "#/responses/415Error"
         422:

--- a/content/akeneo-web-api.yaml
+++ b/content/akeneo-web-api.yaml
@@ -372,6 +372,8 @@ paths:
           schema:
             $ref: "#/definitions/Product"
       responses:
+        201:
+          $ref: "#/responses/Created"
         204:
           $ref: "#/responses/NoContent"
         401:
@@ -628,6 +630,8 @@ paths:
           schema:
             $ref: "#/definitions/Category"
       responses:
+        201:
+          $ref: "#/responses/Created"
         204:
           $ref: "#/responses/NoContent"
         400:
@@ -834,6 +838,8 @@ paths:
           schema:
             $ref: "#/definitions/Family"
       responses:
+        201:
+          $ref: "#/responses/Created"
         204:
           $ref: "#/responses/NoContent"
         400:
@@ -1076,6 +1082,8 @@ paths:
           schema:
             $ref: "#/definitions/Attribute"
       responses:
+        201:
+          $ref: "#/responses/Created"
         204:
           $ref: "#/responses/NoContent"
         400:
@@ -1252,6 +1260,8 @@ paths:
           schema:
             $ref: "#/definitions/AttributeOption"
       responses:
+        201:
+          $ref: "#/responses/Created"
         204:
           $ref: "#/responses/NoContent"
         400:

--- a/content/akeneo-web-api.yaml
+++ b/content/akeneo-web-api.yaml
@@ -1392,7 +1392,7 @@ paths:
     post:
       summary: Create a new media file
       operationId: "media_file_post"
-      description: This endpoint allows you to create a new media file and to associate it to the product value of a given product.
+      description: This endpoint allows you to create a new media file and associate it to the product value of a given product.
       tags:
         - Media files
       parameters:
@@ -1422,7 +1422,7 @@ paths:
         403:
           $ref: "#/responses/403Error"
         415:
-          $ref: "#/responses/415Error"
+          $ref: "#/responses/415ErrorMultipart"
         422:
           $ref: "#/responses/422Error"
   /media-files/{code}:
@@ -2460,7 +2460,7 @@ responses:
     }
   415Error:
     description: Unsupported Media type
-    x-details: The `Content-type` header is not `application/json` but it should
+    x-details: The `Content-type` header has to be `application/json`
     schema:
       $ref: "#/definitions/Error"
     examples: {
@@ -2469,12 +2469,21 @@ responses:
     }
   415ErrorStream:
     description: Unsupported Media type
-    x-details: The `Content-type` header is not `application/vnd.akeneo.collection+json` but it should
+    x-details: The `Content-type` header has to be `application/vnd.akeneo.collection+json`
     schema:
       $ref: "#/definitions/Error"
     examples: {
       "code": 415,
       "message": "‘xxx’ in ‘Content-type’ header is not valid.  Only ‘application/vnd.akeneo.collection+json’ is allowed."
+    }
+  415ErrorMultipart:
+    description: Unsupported Media type
+    x-details: The `Content-type` header has to be `multipart/form-data`
+    schema:
+      $ref: "#/definitions/Error"
+    examples: {
+      "code": 415,
+      "message": "‘xxx’ in ‘Content-type’ header is not valid.  Only ‘multipart/form-data’ is allowed."
     }
   422Error:
     description: Unprocessable entity

--- a/content/responses.md
+++ b/content/responses.md
@@ -216,7 +216,7 @@ HTTP/1.1 200 OK
 ```
 
 ### 201 success
-Creating a resource results in a `201 Created` response. In the `Location` header, you will find the route to access the newly created entity.
+Creating a resource results in a `201 Created` response. In the `Location` header, you will find the route to access the newly created resource.
 
 #### Example
 ```http
@@ -225,9 +225,10 @@ Location: https://demo.akeneo.com/api/rest/v1/categories/winter
 ```
 
 ### 204 success
-Updating or deleting a resource results in a `204 No Content` response.
+Updating or deleting a resource results in a `204 No Content` response. In the `Location` header, you will find the route to access the updated resource.
 
 #### Example
 ```http
 HTTP/1.1 204 No Content
+Location: https://demo.akeneo.com/api/rest/v1/categories/summer
 ```


### PR DESCRIPTION
This PR fix:
- HTTP code 201 and 204 used when patching a resource
- location header returned in 201 and 204 responses
- error message of the error 415 when creating media a media
