### PR TITLE
Initialise documentation of the PHP client

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var tasks = requireDir('./tasks');
 
 // Clean dist directory
 gulp.task('clean-dist', function () {
-  return del(['dist/*']);
+  return del(['dist/*', 'tmp/*']);
 });
 
 // Watch if markdown, less, html or image files have changed
@@ -15,6 +15,7 @@ gulp.task('clean-dist', function () {
 // Should be used for dev purpose
 gulp.task('watch', ['create-dist'], function() {
   gulp.watch('content/*.md', ['create-dist']);
+  gulp.watch('content/php-client/*.md', ['create-dist']);
   gulp.watch('styles/*.less', ['create-dist']);
   gulp.watch('src/*.handlebars', ['create-dist']);
   gulp.watch('src/api-reference/*.handlebars',['create-dist']);
@@ -39,7 +40,8 @@ gulp.task('create-dist', [
   'copy-assets',
   'reference',
   'landings',
-  'documentation'
+  'documentation',
+  'client-documentation'
 ]);
 
 // Main task that should be used for development purpose

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "gulp-prompt": "0.2.0",
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
+    "gulp-remote-src": "0.4.2",
     "gulp-rsync": "0.0.7",
     "gulp-swagger": "1.0.1",
     "gulp-util": "3.0.8",

--- a/src/api-reference/index.handlebars
+++ b/src/api-reference/index.handlebars
@@ -1,4 +1,4 @@
-{{#> layout title="Complete API Reference" active="api-reference"}}
+{{#> layout active_api_reference=true }}
     <div class="container">
         <div class="row">
             <div class="col-md-offset-2 col-md-8">

--- a/src/api-reference/reference.handlebars
+++ b/src/api-reference/reference.handlebars
@@ -1,4 +1,4 @@
-{{#> layout title="Complete API Reference" active="api-reference"}}
+{{#> layout active_api_reference=true }}
     <div class="container">
         <div class="row">
             <div id="navbar" class="col-sm-3 hidden-xs">

--- a/src/documentation.handlebars
+++ b/src/documentation.handlebars
@@ -1,4 +1,5 @@
-{{#> layout title="Api Docs" active="documentation"}}
+{{!-- Shared template for the documentation page and the PHP client --}}
+{{#> layout }}
     <div class="container">
         <div class="row">
             {{{mainContent}}}

--- a/src/getting-started-admin.handlebars
+++ b/src/getting-started-admin.handlebars
@@ -1,4 +1,4 @@
-{{#> layout title="Get started!" active="getting-started"}}
+{{#> layout active_getting_started=true }}
     <div class="container">
         <div class="row">
             <div class="col-md-offset-2 col-md-8 col-xs-offset-1 col-xs-11">

--- a/src/getting-started.handlebars
+++ b/src/getting-started.handlebars
@@ -1,4 +1,4 @@
-{{#> layout title="Get started!" active="getting-started"}}
+{{#> layout active_getting_started=true }}
     <div class="container">
         <div class="row">
             <div class="col-md-offset-2 col-md-8 col-xs-offset-1 col-xs-11">

--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -1,4 +1,4 @@
-{{#> layout title="Api Docs"}}
+{{#> layout }}
     <div class="jumbotron">
         <div class="container-fluid">
             <div class="row">

--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -30,15 +30,16 @@
 
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav navbar-right">
-                <li class="dropdown{{#ifvalue active value="getting-started"}} active{{/ifvalue}}">
+                <li class="dropdown{{#if active_getting_started}} active{{/if}}">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Getting started <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a href="/getting-started.html">Make my first request</a></li>
                         <li><a href="/getting-started-admin.html">Manage the access to the API</a></li>
                     </ul>
                 </li>
-                <li class="{{#ifvalue active value="documentation"}}active{{/ifvalue}}"><a href="/documentation/introduction.html">Documentation</a></li>
-                <li class="{{#ifvalue active value="api-reference"}}active{{/ifvalue}}"><a href="/api-reference-index.html">API reference</a></li>
+                <li class="{{#if active_documentation}}active{{/if}}"><a href="/documentation/introduction.html">Documentation</a></li>
+                <li class="{{#if active_api_reference}}active{{/if}}"><a href="/api-reference-index.html">API reference</a></li>
+                <li class="{{#if active_client_documentation}}active{{/if}}"><a href="/php-client/getting-started.html">PHP client</a></li>
             </ul>
             <form class="navbar-form navbar-right">
                 <div class="form-group">

--- a/tasks/client-documentation.js
+++ b/tasks/client-documentation.js
@@ -1,0 +1,256 @@
+/**
+ * Transform Markdown API client documentation to HTML
+ */
+var gulp = require('gulp');
+var MarkdownIt = require('markdown-it');
+var mdToc = require('markdown-it-toc-and-anchor').default;
+var flatmap = require('gulp-flatmap');
+var insert = require('gulp-insert');
+var path = require('path');
+var gulpMarkdownIt = require('gulp-markdown-it-adapter');
+var highlightJs = require('highlightjs');
+var hbs = require('handlebars');
+var gulpHandlebars = require('gulp-handlebars-html')(hbs);
+var fs = require('fs');
+var rename = require('gulp-rename');
+var replace = require('gulp-replace');
+var remoteSrc = require('gulp-remote-src');
+
+/**
+ * Generate the table of content.
+ * @param pages
+ * @param currentPage
+ *
+ * @returns {string}
+ */
+function getTocMarkdown(pages, currentPage) {
+    return "\n\n:::: toc\n\n" + Object.keys(pages).map(function (page) {
+          if (page === currentPage) {
+              return '::: preToc ' + pages[page] + "\n:::\n@[toc]\n:::postToc\n:::";
+          } else {
+              return '::: tocLink [' + pages[page]+ '](/php-client/' + page.replace(/\.md$/, '.html') + ")\n:::";
+          }
+      }).join("\n") + "\n\n::::\n\n";
+}
+
+/**
+ * Highlight code snippet according to the language specified in the markdown.
+ *
+ * @param str
+ * @param lang
+ * @returns {string}
+ */
+function highlight(str, lang) {
+    if (lang && highlightJs.getLanguage(lang)) {
+        try {
+            return '<pre class="hljs"><code>' +
+                highlightJs.highlight(lang, str, true).value +
+                '</code></pre>';
+        } catch (__) {}
+    }
+    return '<pre class="hljs"><code>' + str + '</code></pre>';
+}
+
+gulp.task('client-documentation', ['clean-dist'], function () {
+    var optionsMd = {
+        html: true,
+        xhtmlOut: true,
+        typographer: false,
+        linkify: false,
+        breaks: false,
+        highlight: highlight
+    };
+    var optionsToc = {
+        toc: true,
+        tocFirstLevel: 2,
+        tocLastLevel: 3,
+        anchorLink: true,
+        anchorLinkSpace: false,
+        anchorLinkBefore: true,
+        tocClassName: 'nav'
+    };
+
+    var md = new MarkdownIt('default', optionsMd);
+
+    function imageTokenOverride(tokens, idx, options, env, self) {
+        return '<img class="img-responsive" alt="'+ tokens[idx].content +'" src="'+ tokens[idx].attrs[0][1] + '"/>';
+    }
+    md.renderer.rules['image'] = imageTokenOverride;
+    md.renderer.rules.table_open = function(tokens, idx) {
+        return '<table class="table">';
+    };
+    md.renderer.rules.heading_open = function(tokens, idx) {
+        return '<a class="anchor" id="' + tokens[idx].attrs[0][1] + '"></a>'+
+            '<'+tokens[idx].tag+' title-id="' + tokens[idx].attrs[0][1] + '">';
+    };
+
+    md.use(require('markdown-it-container'), 'danger', {
+        validate: function(params) {
+            return params.trim().match(/^danger(.*)$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '<div class="alert alert-danger">' : '</div>\n';
+        }
+    })
+    .use(require('markdown-it-container'), 'warning', {
+        validate: function(params) {
+            return params.trim().match(/^warning(.*)$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '<div class="alert alert-warning">' : '</div>\n';
+        }
+    })
+    .use(require('markdown-it-container'), 'info', {
+        validate: function(params) {
+            return params.trim().match(/^info(.*)$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '<div class="alert alert-info">' : '</div>\n';
+        }
+    })
+    .use(require('markdown-it-container'), 'dodont', {
+        validate: function(params) {
+            return params.trim().match(/^dodont(.*)$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '<div class="row">' :
+                '</div>\n';
+        }
+    })
+    .use(require('markdown-it-container'), 'dont', {
+        validate: function(params) {
+            return params.trim().match(/^dont(.*)$/);
+        },
+        render: function (tokens, idx) {
+            var text = tokens[idx].info.trim().match(/^dont\s+(.*).*$/);
+            return (tokens[idx].nesting === 1) ?
+            '<div class="col-xs-6">'+
+            '<div class="panel panel-danger" data-text="' +  md.utils.escapeHtml(text[1]) + '">'+
+            '<div class="panel-body">' :
+                '<strong>DON\'T</strong></div>\n</div>\n</div>\n';
+        }
+    })
+    .use(require('markdown-it-container'), 'do', {
+        validate: function(params) {
+            return params.trim().match(/^do(.*)$/);
+        },
+        render: function (tokens, idx) {
+            var text = tokens[idx].info.trim().match(/^do\s+(.*).*$/);
+            return (tokens[idx].nesting === 1) ?
+            '<div class="col-xs-6">'+
+            '<div class="panel panel-success" data-text="' +  md.utils.escapeHtml(text[1]) + '">'+
+            '<div class="panel-body">' :
+                '<strong>DO</strong></div>\n</div>\n</div>\n';
+        }
+    });
+
+    md.use(mdToc, optionsToc)
+    .use(require('markdown-it-container'), 'toc', {
+        validate: function(params) {
+            return params.trim().match(/^toc$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '<div id="navbar" class="col-sm-3 hidden-xs">' +
+            '<nav role="tablist" id="navbar-nav" data-spy="affix" data-offset-top="80" class="affix-top"><ul class="nav nav-stacked">' :
+                "</ul></nav></div>\n";
+        }
+    })
+    .use(require('markdown-it-container'), 'preToc', {
+        validate: function(params) {
+            return params.trim().match(/^preToc .*/);
+        },
+        render: function (tokens, idx) {
+            var text = tokens[idx].info.trim().match(/^preToc (.*)$/);
+            return (tokens[idx].nesting === 1) ? '<li class="active"><a href="#">' + text[1] + '</a>': '';
+        }
+    })
+    .use(require('markdown-it-container'), 'postToc', {
+        validate: function(params) {
+            return params.trim().match(/^postToc$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '</li>' : '';
+        }
+    })
+    .use(require('markdown-it-container'), 'mainContent', {
+        validate: function(params) {
+            return params.trim().match(/^mainContent$/);
+        },
+        render: function (tokens, idx) {
+            return (tokens[idx].nesting === 1) ? '<div class="col-xs-12 col-sm-9">' : '</div>';
+        }
+    })
+    .use(require('markdown-it-container'), 'tocLink', {
+        validate: function(params) {
+            return params.trim().match(/^tocLink\s+(.*)$/);
+        },
+        render: function (tokens, idx) {
+            var linkTitle = tokens[idx].info.trim().match(/^tocLink.*\[(.*)\]\(.*\)$/);
+            var link = tokens[idx].info.trim().match(/^tocLink.*\((.*)\)$/);
+            return (tokens[idx].nesting === 1) ? '<li><a href="' + md.utils.escapeHtml(link[1]) + '">' + linkTitle[1] + '</a></li>' : '';
+        }
+    })
+
+    .use(require('markdown-it-container'), 'panel-link', {
+        validate: function(params) {
+            return params.trim().match(/^panel-link\s+(.*)$/);
+        },
+        render: function (tokens, idx) {
+            var text = tokens[idx].info.trim().match(/^panel-link\s+(.*)\[.*\].*$/);
+            var linkTitle = tokens[idx].info.trim().match(/^panel-link\s+.*\[(.*)\].*$/);
+            var link = tokens[idx].info.trim().match(/^panel-link\s+.*\((.*)\)$/);
+            if (tokens[idx].nesting === 1) {
+                // opening tag
+                return '<div class="row" style="margin-top: 80px;"><div class="col-sm-offset-3 col-sm-6">' +
+                    '<div class="panel panel-default panel-landing-page panel-clickable">'+
+                    '<a href="' + md.utils.escapeHtml(link[1]) + '">' +
+                    '<div class="panel-body">' +
+                    '<p>'+ md.utils.escapeHtml(text[1]) + '</p>'+
+                    '<p>'+ md.utils.escapeHtml(linkTitle[1]) + '</p>';
+            } else {
+                // closing tag
+                return '</div></a></div></div></div>\n';
+            }
+        }
+    });
+
+    var pages = {
+        'getting-started.md': 'Getting started',
+        'category.md': 'Categories',
+    };
+
+    /*
+     * First, download the getting started from Github in temporary directory and rename as getting started.
+     * Then, transform the markdown into html and add some custom style.
+     * Then, add this generated html into the documentation template.
+     * Then, rename the file from "md" to "html".
+     * Finally, move the file to dist directory.
+     */
+    return remoteSrc(['README.md'], {
+            base: 'https://raw.githubusercontent.com/akeneo/php-api-client/master/'
+        })
+        .pipe(rename('getting-started.md'))
+        .pipe(gulp.dest('./tmp/php-client-github'))
+        .on('end', function () {
+            return gulp.src(['content/php-client/*.md', 'tmp/php-client-github/*.md'])
+                .pipe(flatmap(function(stream, file){
+                    return gulp.src(file.path)
+                        .pipe(insert.wrap("::::: mainContent\n", "\n:::::"))
+                        .pipe(insert.prepend(getTocMarkdown(pages, path.basename(file.path)) + "\n"))
+                        .pipe(gulpMarkdownIt(md))
+                        .pipe(gulp.dest('tmp/php-client'))
+                        .on('end', function () {
+                            return gulp.src('src/documentation.handlebars')
+                                .pipe(gulpHandlebars({
+                                    active_client_documentation: true,
+                                    mainContent: fs.readFileSync('tmp/php-client/' + path.basename(file.path).replace(/\.md/, '.html'))
+                                }, {
+                                    partialsDirectory: ['./src/partials']
+                                }))
+                                .pipe(rename(path.basename(file.path).replace(/\.md/, '.html')))
+                                .pipe(gulp.dest('./dist/php-client'));
+                        })
+                }));
+        });
+    }
+);

--- a/tasks/documentation.js
+++ b/tasks/documentation.js
@@ -15,14 +15,6 @@ var fs = require('fs');
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 
-hbs.registerHelper('ifvalue', function (conditional, options) {
-    if (options.hash.value === conditional) {
-        return options.fn(this)
-    } else {
-        return options.inverse(this);
-    }
-});
-
 function getTocMarkdown(pages, currentPage) {
     return "\n\n:::: toc\n\n" + Object.keys(pages).map(function (page) {
           if (page === currentPage) {
@@ -228,6 +220,7 @@ gulp.task('documentation', ['clean-dist'], function () {
               .on('end', function () {
                   return gulp.src('src/documentation.handlebars')
                     .pipe(gulpHandlebars({
+                        active_documentation:  true,
                         mainContent: fs.readFileSync('tmp/' + path.basename(file.path).replace(/\.md/, '.html'))
                     }, {
                         partialsDirectory: ['./src/partials']


### PR DESCRIPTION
Initialise the client documentation:

- By adding a PHP client menu
![screen shot 2017-06-07 at 10 44 54](https://user-images.githubusercontent.com/1942439/26869884-5f8cab52-4b6e-11e7-973b-06e1a7c228c7.png)

- Refactor the active page mechanism to share the same template "documentation" between php-client and documenation page: first step to not have duplicated code everywhere.

- initialise `client-documentation.js` to download the getting started from github
For now, it's very similar to `documentation.js`.

It has been tested with a part of "category.md" documentation (file not in this PR), and it generates correctly the page:

![screen shot 2017-06-07 at 10 54 49](https://user-images.githubusercontent.com/1942439/26870283-c7498958-4b6f-11e7-9714-9c2282cc610b.png)


What's left ?

- Writing all the documentation in the directory `content/php-client`.
- Parsing only a part of the getting-started from github (as Algolia do: the introduction part on github is useless in the documentation).
- some css style I suppose
- refactoring of gulp tasks to be a little bit more generic for potential future client
