### PR TITLE
Add missing part of the documentation of the API

### DIFF
--- a/content/php-client/authentication.md
+++ b/content/php-client/authentication.md
@@ -11,7 +11,7 @@ You can authenticate to the client with your credentials client id/secret and yo
 
 require_once '/vendor/autoload.php';
 
-$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$clientBuilder = new \Akeneo\Pim\AkeneoPimClientBuilder('http://localhost/');
 $client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 ```
 
@@ -34,7 +34,7 @@ That's why you can create a client with the couple token/refresh token instead o
 
 require_once '/vendor/autoload.php';
 
-$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$clientBuilder = new \Akeneo\Pim\AkeneoPimClientBuilder('http://localhost/');
 $client = $clientBuilder->buildAuthenticatedByToken('client_id', 'secret', 'token', 'refresh_token');
 ```
 
@@ -58,7 +58,7 @@ This is a very basic example to put token and refresh token into a file, in orde
 
 require_once '/vendor/autoload.php';
 
-$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$clientBuilder = new \Akeneo\Pim\AkeneoPimClientBuilder('http://localhost/');
 if (!file_exists('/tmp/akeneo_token.tmp')) {
     $client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 } else {

--- a/content/php-client/authentication.md
+++ b/content/php-client/authentication.md
@@ -1,0 +1,73 @@
+# Authentication
+
+You can be authenticated to the API either by providing a username and a password or by providing a token and a refresh token.
+
+## By username/password
+
+You can authenticate to the client with your credentials client id/secret and your user/password:
+
+```php
+<?php
+
+require_once '/vendor/autoload.php';
+
+$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+```
+
+Then, every request made by the client is automatically authenticated.
+If you don't have any client id, please take a look at [this page](/documentation/security.html#authentication) to create it.
+
+This is the easiest way to authenticate the client.
+
+## By token/refresh token
+
+The main drawback of the authentication by password is that it requests a new token before doing any call to the API. Therefore, it can decrease the performance if you use the PHP client in an application that creates a lot of processes.
+For example, in a PHP web application, a new PHP process is created for each request. If would be time consuming to get a new token for each process, in order to be authenticated.
+
+In this context, it's better to use the same token for each new request.
+
+That's why you can create a client with the couple token/refresh token instead of username/password.
+
+```php
+<?php
+
+require_once '/vendor/autoload.php';
+
+$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$client = $clientBuilder->buildAuthenticatedByToken('client_id', 'secret', 'token', 'refresh_token');
+```
+
+To get the couple token/refresh token, you just have to do:
+```php
+$client->getToken();
+$client->getRefreshToken();
+```
+
+::: warning
+It's your responsibility to store the token and the refresh token.
+For example, it can be stored in a file or in a database.
+:::
+
+### Example
+
+This is a very basic example to put token and refresh token into a file, in order to be shared with other processes:
+
+```php
+<?php
+
+require_once '/vendor/autoload.php';
+
+$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+if (!file_exists('/tmp/akeneo_token.tmp')) {
+    $client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+} else {
+    $credentials = file_get_contents('/tmp/akeneo_token.tmp');
+    list($token, $refreshToken) = implode(':', $credentials);
+    $client = $clientBuilder->buildAuthenticatedByToken('client_id', 'secret', $token, $refresToken);
+}
+
+$category = $client->getCategoryApi()->get('master');
+
+file_put_contents('/tmp/akeneo_token.tmp', $client->getToken() . ':' . $client->getRefreshToken);
+```

--- a/content/php-client/exception.md
+++ b/content/php-client/exception.md
@@ -1,0 +1,128 @@
+# Exception handling
+
+Every request made with the client can throw an HTTP exception.
+
+## HTTP exception
+
+The parent of these HTTP exceptions is `Akeneo\Pim\Exception\HttpException`.
+You can get the request and the response that are responsible of this exception. Also, the HTTP response code and response message are available.
+ 
+```php
+try {
+    $client->getProductApi()->get('top');
+} catch (HttpException $e) {
+    // do your stuff with the exception
+    $requestBody = $e->getRequest()->getBody();
+    $responseBody = $e->getResponse()->getBody();
+    $httpCode = $e->getCode(); 
+    $errorMessage = $e->getMessage(); 
+}
+```
+
+ 
+Two types of exception inherit from this exception: server exception and client exception.
+
+## Server exception
+
+A server exception thrown by the client means that the server failed to fulfill an apparently valid request.
+It's an HTTP code from the 5xx family.
+
+This exception is `Akeneo\Pim\Exception\ServerErrorHttpException`.
+
+```php
+try {
+    $client->getProductApi()->get('top');
+} catch (ServerErrorHttpException $e) {
+    // do your stuff with the exception
+    $requestBody = $e->getRequest()->getBody();
+    $responseBody = $e->getResponse()->getBody();
+    $httpCode = $e->getCode(); 
+    $errorMessage = $e->getMessage(); 
+}
+```
+
+## Client exception
+
+A client exception could be thrown if the client made an invalid request.
+It's an HTTP code from the 4xx family.
+
+This exception is `Akeneo\Pim\Exception\ClientErrorHttpException`. It is subdivided in several specific exceptions.
+
+### Bad request exception
+
+This exception is thrown if the request does not contain valid JSON. It corresponds to the HTTP code 400.
+
+```php
+try {
+    $client->getProductApi()->get('top');
+} catch (BadRequestHttpException $e) {
+    // do your stuff with the exception
+    $requestBody = $e->getRequest()->getBody();
+    $responseBody = $e->getResponse()->getBody();
+    $httpCode = $e->getCode(); 
+    $errorMessage = $e->getMessage(); 
+}
+```
+
+::: info
+It should not occur with the PHP client, because the JSON is generated from PHP array.
+:::
+
+### Not found exception
+
+This exception is thrown if the requested resource does not exist. It corresponds to the HTTP code 404.
+
+```php
+try {
+    $client->getProductApi()->get('top');
+} catch (NotFoundHttpException $e) {
+    // do your stuff with the exception
+    $requestBody = $e->getRequest()->getBody();
+    $responseBody = $e->getResponse()->getBody();
+    $httpCode = $e->getCode(); 
+    $errorMessage = $e->getMessage(); 
+}
+```
+
+### Unauthorized exception
+
+This exception is thrown if you don't have the permission to access to the resource. It corresponds to the HTTP code 401.
+
+```php
+try {
+    $client->getProductApi()->get('top');
+} catch (UnauthorizedHttpException $e) {
+    // do your stuff with the exception
+    $requestBody = $e->getRequest()->getBody();
+    $responseBody = $e->getResponse()->getBody();
+    $httpCode = $e->getCode(); 
+    $errorMessage = $e->getMessage(); 
+}
+```
+
+::: info
+It should not occur as the PHP client automatically authenticates the request for you.
+:::
+
+### Unprocessable entity exception
+
+This exception is thrown if the data are not valid. In this exception, an array of errors could be returned.
+It returns an empty array if there is no error in the array.
+
+```php
+try {
+    $client->getProductApi()->create('top');
+} catch (UnprocessableEntityHttpException $e) {
+    // do your stuff with the exception
+    $requestBody = $e->getRequest()->getBody();
+    $responseBody = $e->getResponse()->getBody();
+    $httpCode = $e->getCode(); 
+    $errorMessage = $e->getMessage(); 
+    $errors = $e->getResponseErrors();
+    foreach ($e->getResponseErrors() as $error) {
+        // do your stuff with the error
+        echo $error['code'];
+        echo $error['message'];
+    }
+}
+```

--- a/content/php-client/getting-started.md
+++ b/content/php-client/getting-started.md
@@ -1,0 +1,64 @@
+# Getting started
+
+## Requirements
+
+* PHP >= 5.6
+* Composer
+
+## Installation
+
+`api-php-client` uses [Composer](http://getcomposer.org).
+The first step to use `api-php-client` is to download Composer:
+
+```bash
+$ curl -s http://getcomposer.org/installer | php
+```
+We use HTTPPlug as the HTTP client abstraction layer. If you want to know more about this, it's documented [here](/php-client/http-client.html).
+In this example, we will use [Guzzle](https://github.com/guzzle/guzzle) v6 as the HTTP client implementation.
+
+Run the following command to require the libraries in your project:
+```bash
+$ php composer.phar require akeneo/api-php-client php-http/guzzle6-adapter
+```
+
+::: info
+If you don't know which implementation to choose, we strongly recommend you to use Guzzle v6, as in the previous example.
+:::
+
+## Initialisation of the client
+
+You first need to initialise the client with your credentials client id/secret and with your user/password.
+
+If you don't have any client id/secret, let's take a look at [this page](/documentation/security.html#authentication) to create it.
+
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+```
+
+You can authenticate to the client with your token/refresh token as well.
+```php
+<?php
+
+require_once __DIR__ . '/vendor/autoload.php';
+
+$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$client = $clientBuilder->buildAuthenticatedByToken('client_id', 'secret', 'token', 'refresh_token');
+```
+
+Want to know more about authentication? It's over [there](/php-client/authentication.html).
+
+## Make your first call
+
+Getting a product is as simple as:
+
+```
+$product = $client->getProductApi()->get('top');
+echo $product['identifier'];
+```
+
+Want to [update an attribute](/php-client/resources.html#upsert-an-attribute), [create a category](/php-client/resources.html#create-a-category) or [delete a product](/php-client/resources.html#delete-a-product) ? You can get code snippets for all the resources [here](/php-client/resources.html).

--- a/content/php-client/getting-started.md
+++ b/content/php-client/getting-started.md
@@ -36,7 +36,7 @@ If you don't have any client id/secret, let's take a look at [this page](/docume
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$clientBuilder = new \Akeneo\Pim\AkeneoPimClientBuilder('http://localhost/');
 $client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 ```
 
@@ -46,7 +46,7 @@ You can authenticate to the client with your token/refresh token as well.
 
 require_once __DIR__ . '/vendor/autoload.php';
 
-$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$clientBuilder = new \Akeneo\Pim\AkeneoPimClientBuilder('http://localhost/');
 $client = $clientBuilder->buildAuthenticatedByToken('client_id', 'secret', 'token', 'refresh_token');
 ```
 

--- a/content/php-client/http-client.md
+++ b/content/php-client/http-client.md
@@ -43,6 +43,6 @@ $ php composer.phar require akeneo/api-php-client php-http/curl-client slim/slim
 Then, when creating the client, the HTTP client to use will be automatically detected:
  
  ```
-$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$clientBuilder = new \Akeneo\Pim\AkeneoPimClientBuilder('http://localhost/');
 $client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 ```

--- a/content/php-client/http-client.md
+++ b/content/php-client/http-client.md
@@ -1,0 +1,48 @@
+# HTTP client abstraction
+
+We use [HTTPPlug](http://httplug.io/) as the HTTP client abstraction layer. 
+Thanks to it, you are free to use the HTTP client implementation and PSR7 implementation that fits your needs.
+ 
+For example, if you already are using Guzzle v5 in an existing project, you can use it with Akeneo PHP client as well. 
+Also, it can avoid dependency conflicts that you can experienced by using different version of an HTTP client in the same project (Guzzle v5 and Guzzle v6 for example).
+
+Don't know which client or PSR7 implementation to use? We recommend you to use Guzzle v6:
+
+```bash
+$ php composer.phar require akeneo/api-php-client php-http/guzzle6-adapter
+```
+::: info
+Guzle v6 automatically requires its own PSR7 implementation `guzzlehttp/psr7`.
+:::
+
+You can get the full list of HTTP adapters [here](https://packagist.org/providers/php-http/client-implementation).
+
+The currently supported HTTP client implementation are:
+
+- php-http/guzzle6-adapter (only with Guzzle PSR7 implementation)
+- php-http/curl-client
+- php-http/guzzle5-adapter
+
+The currently supported PSR7 implementation are:
+- guzzlehttp/psr7
+- zendframework/zend-diactoros
+- slim/slim
+
+In order to use Guzzle v5 and PSR7 Guzzle implementation, you have to do it:
+
+```bash
+$ php composer.phar require akeneo/api-php-client php-http/guzzle5-adapter guzzlehttp/psr7
+```
+
+If you prefer the native curl client, with Slim PSR7 implementation:
+
+```bash
+$ php composer.phar require akeneo/api-php-client php-http/curl-client slim/slim
+```
+
+Then, when creating the client, the HTTP client to use will be automatically detected:
+ 
+ ```
+$clientBuilder = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://localhost/');
+$client = $clientBuilder->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+```

--- a/content/php-client/resources.md
+++ b/content/php-client/resources.md
@@ -1,0 +1,1 @@
+# Resources

--- a/content/php-client/resources/attribute-options.md
+++ b/content/php-client/resources/attribute-options.md
@@ -3,7 +3,7 @@
 ### Get an attribute option
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -29,7 +29,7 @@ There are two ways of getting attribute options.
 This method allows to get attribute options page per page, as a classical pagination.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getAttributeOptionApi()->listPerPage('a_simple_select', 50, true);
 ```
@@ -41,7 +41,7 @@ You can get more information about this method [here](/php-client/list-resources
 This method allows to iterate the attribute options. It will automatically get the next pages for you.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $attributes = $client->getAttributeOptionApi()->all('a_simple_select', 50);
 ```
@@ -53,7 +53,7 @@ You can get more information about this method [here](/php-client/list-resources
 If the attribute option does not exist yet, this method creates it, otherwise it throws an exception.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getAttributeOptionApi()->create('a_simple_select', 'black', [
     [
@@ -71,7 +71,7 @@ $client->getAttributeOptionApi()->create('a_simple_select', 'black', [
 If the attribute option does not exist yet, this method creates it, otherwise it updates it.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getAttributeOptionApi()->upsert('a_simple_select', 'black', [
     [

--- a/content/php-client/resources/attribute-options.md
+++ b/content/php-client/resources/attribute-options.md
@@ -1,6 +1,6 @@
-# Attribute option
+## Attribute option
 
-## Get an attribute option
+### Get an attribute option
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -20,11 +20,11 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $attributeOption = $client->getAttributeOptionApi()->get('a_simple_select', 'black');
 ```
 
-## Get a list of attribute options
+### Get a list of attribute options
 
 There are two ways of getting attribute options. 
 
-### By getting pages
+#### By getting pages
 
 This method allows to get attribute options page per page, as a classical pagination.
 
@@ -36,7 +36,7 @@ $firstPage = $client->getAttributeOptionApi()->listPerPage('a_simple_select', 50
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the attribute options. It will automatically get the next pages for you.
 
@@ -48,7 +48,7 @@ $attributes = $client->getAttributeOptionApi()->all('a_simple_select', 50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-## Create an attribute 
+### Create an attribute 
 
 If the attribute option does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -66,7 +66,7 @@ $client->getAttributeOptionApi()->create('a_simple_select', 'black', [
 ]);
 ```
 
-## Upsert an attribute option
+### Upsert an attribute option
 
 If the attribute option does not exist yet, this method creates it, otherwise it updates it.
 

--- a/content/php-client/resources/attributes.md
+++ b/content/php-client/resources/attributes.md
@@ -1,6 +1,6 @@
-# Attribute
+## Attribute
 
-## Get an attribute 
+### Get an attribute 
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -42,11 +42,11 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $attribute = $client->getAttributeApi()->get('release_date');
 ```
 
-## Get a list of attributes
+### Get a list of attributes
 
 There are two ways of getting attributes. 
 
-### By getting page
+#### By getting page
 
 This method allows to get attributes page per page, as a classical pagination.
 It's possible to get the total number of attributes with this method.
@@ -59,7 +59,7 @@ $firstPage = $client->getAttributeApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the attributes. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of attributes.
@@ -72,7 +72,7 @@ $attributes = $client->getAttributeApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-## Create an attribute 
+### Create an attribute 
 
 If the attribute does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -111,7 +111,7 @@ $client->getAttributeApi()->create('release_date', [
 ]);
 ```
 
-## Upsert an attribute 
+### Upsert an attribute 
 
 If the attribute does not exist yet, this method creates it, otherwise it updates it.
 
@@ -150,7 +150,7 @@ $client->getAttributeApi()->upsert('release_date', [
 ]);
 ```
 
-## Upsert a list of attributes 
+### Upsert a list of attributes 
 
 This method allows to create or update a list of attributes.
 It has the same behavior as the `upsert` method for a single attribute, except that the code must be specified in the data of each attribute.

--- a/content/php-client/resources/attributes.md
+++ b/content/php-client/resources/attributes.md
@@ -3,7 +3,7 @@
 ### Get an attribute 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -52,7 +52,7 @@ This method allows to get attributes page per page, as a classical pagination.
 It's possible to get the total number of attributes with this method.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getAttributeApi()->listPerPage(50, true);
 ```
@@ -65,7 +65,7 @@ This method allows to iterate the attributes. It will automatically get the next
 With this method, it's not possible to get the previous page, or getting the total number of attributes.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $attributes = $client->getAttributeApi()->all(50);
 ```
@@ -77,7 +77,7 @@ You can get more information about this method [here](/php-client/list-resources
 If the attribute does not exist yet, this method creates it, otherwise it throws an exception.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getAttributeApi()->create('release_date', [
     'type'                   => 'pim_catalog_date',
@@ -116,7 +116,7 @@ $client->getAttributeApi()->create('release_date', [
 If the attribute does not exist yet, this method creates it, otherwise it updates it.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getAttributeApi()->upsert('release_date', [
     'type'                   => 'pim_catalog_date',
@@ -157,7 +157,7 @@ It has the same behavior as the `upsert` method for a single attribute, except t
 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getAttributeApi()->upsertList([
     [

--- a/content/php-client/resources/categories.md
+++ b/content/php-client/resources/categories.md
@@ -3,7 +3,7 @@
 ### Get a category 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -28,7 +28,7 @@ There are two ways of getting categories.
 This method allows to get categories page per page, as a classical pagination.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getCategoryApi()->listPerPage(50, true);
 ```
@@ -40,7 +40,7 @@ You can get more information about this method [here](/php-client/list-resources
 This method allows to iterate the categories. It will automatically get the next pages for you.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $categories = $client->getCategoryApi()->all(50);
 ```
@@ -52,7 +52,7 @@ You can get more information about this method [here](/php-client/list-resources
 If the category does not exist yet, this method creates it, otherwise it throws an exception.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getCategoryApi()->create('winter_collection', [
     'parent' => 'master',
@@ -68,7 +68,7 @@ $client->getCategoryApi()->create('winter_collection', [
 If the category does not exist yet, this method creates it, otherwise it updates it.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getCategoryApi()->upsert('winter_collection', [
     'parent' => 'master',
@@ -86,7 +86,7 @@ It has the same behavior as the `upsert` method for a single category, except th
 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getCategoryApi()->upsertList([
     [

--- a/content/php-client/resources/categories.md
+++ b/content/php-client/resources/categories.md
@@ -1,6 +1,6 @@
-# Category
+## Category
 
-## Get a category 
+### Get a category 
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -19,11 +19,11 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $category = $client->getCategoryApi()->get('master');
 ```
 
-## Get a list of categories
+### Get a list of categories
 
 There are two ways of getting categories. 
 
-### By getting pages
+#### By getting pages
 
 This method allows to get categories page per page, as a classical pagination.
 
@@ -35,7 +35,7 @@ $firstPage = $client->getCategoryApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the categories. It will automatically get the next pages for you.
 
@@ -47,7 +47,7 @@ $categories = $client->getCategoryApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-## Create a category
+### Create a category
 
 If the category does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -63,7 +63,7 @@ $client->getCategoryApi()->create('winter_collection', [
 ]);
 ```
 
-## Upsert a category
+### Upsert a category
 
 If the category does not exist yet, this method creates it, otherwise it updates it.
 
@@ -79,7 +79,7 @@ $client->getCategoryApi()->upsert('winter_collection', [
 ]);
 ```
 
-## Upsert a list of categories
+### Upsert a list of categories
 
 This method allows to create or update a list of categories.
 It has the same behavior as the `upsert` method for a single category, except that the code must be specified in the data of each category.

--- a/content/php-client/resources/channels.md
+++ b/content/php-client/resources/channels.md
@@ -1,6 +1,6 @@
-# Channel
+## Channel
 
-## Get a channel
+### Get a channel
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -23,11 +23,11 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $channel = $client->getChannelApi()->get('ecommerce');
 ```
 
-## Get a list of channels
+### Get a list of channels
 
 There are two ways of getting channels. 
 
-### By getting pages
+#### By getting pages
 
 This method allows to get channels page per page, as a classical pagination.
 
@@ -39,7 +39,7 @@ $firstPage = $client->getChannelApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the channels. It will automatically get the next pages for you.
 

--- a/content/php-client/resources/channels.md
+++ b/content/php-client/resources/channels.md
@@ -3,7 +3,7 @@
 ### Get a channel
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -32,7 +32,7 @@ There are two ways of getting channels.
 This method allows to get channels page per page, as a classical pagination.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getChannelApi()->listPerPage(50, true);
 ```
@@ -44,7 +44,7 @@ You can get more information about this method [here](/php-client/list-resources
 This method allows to iterate the channels. It will automatically get the next pages for you.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $channels = $client->getChannelApi()->all(50);
 ```

--- a/content/php-client/resources/families.md
+++ b/content/php-client/resources/families.md
@@ -3,7 +3,7 @@
 ### Get a family 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -34,7 +34,7 @@ This method allows to get families page per page, as a classical pagination.
 It's possible to get the total number of families with this method.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getFamilyApi()->listPerPage(50, true);
 ```
@@ -46,7 +46,7 @@ You can get more information about this method [here](/php-client/list-resources
 This method allows to iterate the families. It will automatically get the next pages for you.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $families = $client->getFamilyApi()->all(50);
 ```
@@ -58,7 +58,7 @@ You can get more information about this method [here](/php-client/list-resources
 If the family does not exist yet, this method creates it, otherwise it throws an exception.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/', 'client_id', 'secret', 'admin', 'admin')->build()
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/', 'client_id', 'secret', 'admin', 'admin')->build()
 
 $client->getFamilyApi()->create('caps', [
      'attributes'             => ['sku', 'name', 'description', 'price', 'color'],
@@ -81,7 +81,7 @@ $client->getFamilyApi()->create('caps', [
 If the family does not exist yet, this method creates it, otherwise it updates it.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getFamilyApi()->upsert('cap', [
      'attributes'             => ['sku', 'name', 'description', 'price', 'color'],
@@ -104,7 +104,7 @@ It has the same behavior as the `upsert` method for a single family, except that
 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getFamilyApi()->upsertList([
     [

--- a/content/php-client/resources/families.md
+++ b/content/php-client/resources/families.md
@@ -1,6 +1,6 @@
-# Family
+## Family
 
-## Get a family 
+### Get a family 
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -24,11 +24,11 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $family = $client->getFamilyApi()->get('master');
 ```
 
-## Get a list of families 
+### Get a list of families 
 
 There are two ways of getting families. 
 
-### By getting pages
+#### By getting pages
 
 This method allows to get families page per page, as a classical pagination.
 It's possible to get the total number of families with this method.
@@ -41,7 +41,7 @@ $firstPage = $client->getFamilyApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the families. It will automatically get the next pages for you.
 
@@ -53,7 +53,7 @@ $families = $client->getFamilyApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-## Create a family 
+### Create a family 
 
 If the family does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -76,7 +76,7 @@ $client->getFamilyApi()->create('caps', [
 
 
 
-## Upsert a family 
+### Upsert a family 
 
 If the family does not exist yet, this method creates it, otherwise it updates it.
 
@@ -97,7 +97,7 @@ $client->getFamilyApi()->upsert('cap', [
 ]);
 ```
 
-## Upsert a list of families 
+### Upsert a list of families 
 
 This method allows to create or update a list of families.
 It has the same behavior as the `upsert` method for a single family, except that the code must be specified in the data of each family.

--- a/content/php-client/resources/locales.md
+++ b/content/php-client/resources/locales.md
@@ -3,7 +3,7 @@
 ### Get a locale 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -24,7 +24,7 @@ There are two ways of getting locales.
 This method allows to get locales page per page, as a classical pagination.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getLocaleApi()->listPerPage(50, true);
 ```
@@ -36,7 +36,7 @@ You can get more information about this method [here](/php-client/list-resources
 This method allows to iterate the locales. It will automatically get the next pages for you.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $locales = $client->getLocaleApi()->all(50);
 ```

--- a/content/php-client/resources/locales.md
+++ b/content/php-client/resources/locales.md
@@ -1,6 +1,6 @@
-# Locale
+## Locale
 
-## Get a locale 
+### Get a locale 
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -15,11 +15,11 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $locale = $client->getLocaleApi()->get('ecommerce');
 ```
 
-## Get a list of locales 
+### Get a list of locales 
 
 There are two ways of getting locales. 
 
-### By getting pages
+#### By getting pages
 
 This method allows to get locales page per page, as a classical pagination.
 
@@ -31,7 +31,7 @@ $firstPage = $client->getLocaleApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the locales. It will automatically get the next pages for you.
 

--- a/content/php-client/resources/media-files.md
+++ b/content/php-client/resources/media-files.md
@@ -3,7 +3,7 @@
 ### Get media file information
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -26,7 +26,7 @@ $product = $client->getProductMediaFileApi()->get('code/example');
 ### Download media file 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $product = $client->getProductMediaFileApi()->download('code/example');
 
@@ -42,7 +42,7 @@ There are two ways of getting media files.
 This method allows to get media files page per page, as a classical pagination.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $firstPage = $client->getProductMediaFileApi()->listPerPage(50, true);
 ```
@@ -55,7 +55,7 @@ This method allows to iterate the media files. It will automatically get the nex
 With this method, it's not possible to get the previous page, or getting the total number of products.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 // get a cursor with a page size of 50, apply a research
 $mediaFiles = $client->getProductMediaFileApi()->all(50);
@@ -68,7 +68,7 @@ You can get more information about this method [here](/php-client/list-resources
 Create a new media file and associate it to a product.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getProductMediaFileApi()->create('/tmp/ziggy.jpg', [
     'identifier' => 'medium_boot',

--- a/content/php-client/resources/media-files.md
+++ b/content/php-client/resources/media-files.md
@@ -1,6 +1,6 @@
-# Media
+## Media
 
-## Get media file information
+### Get media file information
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -23,7 +23,7 @@ $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->b
 $product = $client->getProductMediaFileApi()->get('code/example');
 ```
 
-## Download media file 
+### Download media file 
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -33,11 +33,11 @@ $product = $client->getProductMediaFileApi()->download('code/example');
 file_put_contents('/tmp/ziggy.jpg', $product->getContents());
 ```
 
-## Get a list of media file information 
+### Get a list of media file information 
 
 There are two ways of getting media files.
 
-### By getting pages
+#### By getting pages
 
 This method allows to get media files page per page, as a classical pagination.
 
@@ -49,7 +49,7 @@ $firstPage = $client->getProductMediaFileApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the media files. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of products.
@@ -63,7 +63,7 @@ $mediaFiles = $client->getProductMediaFileApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-## Create a new media file 
+### Create a new media file 
 
 Create a new media file and associate it to a product.
 

--- a/content/php-client/resources/products.md
+++ b/content/php-client/resources/products.md
@@ -1,6 +1,6 @@
-# Product
+## Product
 
-## Get a product 
+### Get a product 
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -45,11 +45,11 @@ $product = $client->getProductApi()->get('top');
 
 You can get more information about the returned format of the product values [here](/documentation/resources.html#product).
 
-## Get a list of products 
+### Get a list of products 
 
 There are two ways of getting products. Also, you have a search builder to ease the construction of a research.
 
-### Search builder
+#### Search builder
 
 You can search over the products, thanks to a list of filters.
 An helper has been added to ease the construction of these filters.
@@ -68,7 +68,7 @@ $searchBuilder
 $searchFilters = $searchBuilder->getFilters();
 ```
 
-### By getting pages
+#### By getting pages
 
 This method allows to get products page per page, as a classical pagination. You can research products thanks to the search builder.
 
@@ -103,7 +103,7 @@ You can get more information about this method [here](/php-client/list-resources
 
 You can get more information about the available query parameters [here](/api-reference.html#get_products).
 
-### With a cursor
+#### With a cursor
 
 This method allows to iterate the products. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of products.
@@ -132,7 +132,7 @@ You can get more information about this method [here](/php-client/list-resources
 
 You can get more information about the available query parameters [here](/api-reference.html#get_products).
 
-## Create a product 
+### Create a product 
 
 If the product does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -180,7 +180,7 @@ $client->getProductApi()->create('top', [
 
 You can get more information about the expected format of the product values [here](/documentation/resources.html#product).
 
-## Upsert a product 
+### Upsert a product 
 
 If the product does not exist yet, this method creates it, otherwise it updates it.
 
@@ -228,7 +228,7 @@ $client->getProductApi()->upsert('top', [
 
 You can get more information about the expected format of the product values [here](/documentation/resources.html#product).
 
-## Upsert a list of products 
+### Upsert a list of products 
 
 This method allows to create or update a list of products.
 It has the same behavior as the `upsert` method for a single product, except that the code must be specified in the data of each product.
@@ -284,7 +284,7 @@ There is a limit on the maximum number of products that you can upsert in one ti
 
 You can get a complete description of the expected format and the returned format [here](/api-reference.html#get_products__code_).
 
-## Delete a product
+### Delete a product
 
 ```php
 $client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');

--- a/content/php-client/resources/products.md
+++ b/content/php-client/resources/products.md
@@ -3,7 +3,7 @@
 ### Get a product 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 /*
  * Returns an array like this:
@@ -78,7 +78,7 @@ Also, it's possible to filter the value to return, thanks to the query parameter
 For example, in this example, we only return product values belonging to the channel "ecommerce" by adding the query parameter `'scope' => 'ecommerce'`. 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $searchBuilder = new \Akeneo\Pim\Search\SearchBuilder();
 $searchBuilder
@@ -113,7 +113,7 @@ As for the paginated method, the search builder can be used and all query parame
 For example, in this example, we only return product values belonging to the channel "ecommerce" by adding the query parameter `'scope' => 'ecommerce'`. 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $searchBuilder = new \Akeneo\Pim\Search\SearchBuilder();
 $searchBuilder
@@ -137,7 +137,7 @@ You can get more information about the available query parameters [here](/api-re
 If the product does not exist yet, this method creates it, otherwise it throws an exception.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getProductApi()->create('top', [
     'enabled' => true,
@@ -185,7 +185,7 @@ You can get more information about the expected format of the product values [he
 If the product does not exist yet, this method creates it, otherwise it updates it.
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getProductApi()->upsert('top', [
     'enabled' => true,
@@ -235,7 +235,7 @@ It has the same behavior as the `upsert` method for a single product, except tha
 
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $responseLines = $client->getProductApi()->upsertList([
     [
@@ -287,7 +287,7 @@ You can get a complete description of the expected format and the returned forma
 ### Delete a product
 
 ```php
-$client = new \Akeneo\Pim\Client\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
+$client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
 
 $client->getProductApi()->delete('top');
 ```

--- a/tasks/client-documentation.js
+++ b/tasks/client-documentation.js
@@ -15,6 +15,7 @@ var fs = require('fs');
 var rename = require('gulp-rename');
 var replace = require('gulp-replace');
 var remoteSrc = require('gulp-remote-src');
+var concat = require('gulp-concat');
 
 /**
  * Generate the table of content.
@@ -216,31 +217,25 @@ gulp.task('client-documentation', ['clean-dist'], function () {
 
     var pages = {
         'getting-started.md': 'Getting started',
+        'authentication.md': 'Authentication',
+        'exception.md': 'Exception handling',
+        'http-client.md': 'HTTP client abstraction',
         'list-resources.md': 'List resources',
-        'products.md': 'Products',
-        'categories.md': 'Categories',
-        'families.md': 'Families',
-        'attributes.md': 'Attributes',
-        'attribute-options.md': 'Attribute options',
-        'media-files.md': 'Media files',
-        'locales.md': 'Locales',
-        'channels.md': 'Channels'
+        'resources.md': 'Resources'
     };
 
     /*
-     * First, download the getting started from Github in temporary directory and rename as getting started.
+     * First, concat every resource file into the file resource.md
      * Then, transform the markdown into html and add some custom style.
      * Then, add this generated html into the documentation template.
      * Then, rename the file from "md" to "html".
      * Finally, move the file to dist directory.
      */
-    return remoteSrc(['README.md'], {
-            base: 'https://raw.githubusercontent.com/akeneo/php-api-client/master/'
-        })
-        .pipe(rename('getting-started.md'))
-        .pipe(gulp.dest('./tmp/php-client-github'))
+    return gulp.src(['content/php-client/resources.md', 'content/php-client/resources/*.md'])
+        .pipe(concat('resources.md'))
+        .pipe(gulp.dest('tmp/php-client/'))
         .on('end', function () {
-            return gulp.src(['content/php-client/*.md', 'tmp/php-client-github/*.md'])
+            return gulp.src(['content/php-client/*.md', 'tmp/php-client/resources.md'])
                 .pipe(flatmap(function(stream, file){
                     return gulp.src(file.path)
                         .pipe(insert.wrap("::::: mainContent\n", "\n:::::"))


### PR DESCRIPTION
This PR:

- add a getting started (not downloaded from github anymore)
- page on authentication
- page on exception
- page on http client
- concat all resources in one file to avoid big menu
