### PR TITLE
Doc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@
 .DS_Store
 /tmp/
 config.json
+package-lock.json
+yarn.lock

--- a/content/img/illustrations/illus--Attributeoptions.svg
+++ b/content/img/illustrations/illus--Attributeoptions.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>

--- a/content/img/illustrations/illus--Authentication.svg
+++ b/content/img/illustrations/illus--Authentication.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>

--- a/content/img/illustrations/illus--Overview.svg
+++ b/content/img/illustrations/illus--Overview.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>

--- a/content/php-client/resources/products.md
+++ b/content/php-client/resources/products.md
@@ -43,7 +43,7 @@ $client = new \Akeneo\Pim\AkeneoPimClientBuilder('http://akeneo.com/')->buildAut
 $product = $client->getProductApi()->get('top');
 ```
 
-You can get more information about the returned format of the product values [here](/documentation/resources.html#product).
+You can get more information about the returned format of the product values [here](/documentation/resources.html#product-values).
 
 ### Get a list of products 
 
@@ -178,7 +178,7 @@ $client->getProductApi()->create('top', [
 );
 ```
 
-You can get more information about the expected format of the product values [here](/documentation/resources.html#product).
+You can get more information about the expected format of the product values [here](/documentation/resources.html#product-values).
 
 ### Upsert a product 
 
@@ -226,7 +226,7 @@ $client->getProductApi()->upsert('top', [
 );
 ```
 
-You can get more information about the expected format of the product values [here](/documentation/resources.html#product).
+You can get more information about the expected format of the product values [here](/documentation/resources.html#product-values).
 
 ### Upsert a list of products 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,14 +14,11 @@ gulp.task('clean-dist', function () {
 // so as to relaunch the build into dist directory
 // Should be used for dev purpose
 gulp.task('watch', ['create-dist'], function() {
-  gulp.watch('content/*.md', ['create-dist']);
-  gulp.watch('content/php-client/*.md', ['create-dist']);
-  gulp.watch('content/misc/*.md', ['create-dist']);
-  gulp.watch('styles/*.less', ['create-dist']);
-  gulp.watch('src/*.handlebars', ['create-dist']);
-  gulp.watch('src/api-reference/*.handlebars',['create-dist']);
-  gulp.watch('content/img/*', ['create-dist']);
+  gulp.watch('content/**/*.md', ['create-dist']);
+  gulp.watch('content/img/**/*', ['create-dist']);
   gulp.watch('content/*.yaml', ['create-dist']);
+  gulp.watch('styles/*.less', ['create-dist']);
+  gulp.watch('src/**/*.handlebars', ['create-dist']);
 });
 
 // Launch a server with dist directory exposed on it

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "pim-api-docs",
+  "scripts": {
+    "serve": "gulp serve"
+  },
   "dependencies": {
     "jquery": "3.1.1",
     "font-awesome": "4.7.0",

--- a/readme.md
+++ b/readme.md
@@ -6,22 +6,32 @@ The API documentation can be found here: [api.akeneo.com](http://api.akeneo.com)
 ## Installation for dev/preview purposes
 
 ### Requirements
-[Node](https://nodejs.org/en/) is required and [Gulp-cli](https://github.com/gulpjs/gulp-cli) as well.
-
-```bash
-sudo npm install --global n
-sudo n 7.2.0
-npm install
-sudo npm install --global gulp-cli
-```
+[Node.js](https://nodejs.org/en/) is required.
+You can optionally choose [Yarn](https://yarnpkg.com/lang/en/) as package manager instead of NPM (provided with NodeJS by default).
 
 ### Run locally
-Once Node and gulp-cli installed, run:
+First, install the all dependencies with Yarn:
+
+```bash
+yarn install
+```
+
+or with NPM:
 
 ```bash
 npm install
+```
 
-gulp serve
+Then run the Gulp server, with Yarn: 
+
+```bash
+yarn serve
+```
+
+or with NPM:
+
+```bash
+npm serve
 ```
 
 The API documentation site is then available on `localhost:8000`.


### PR DESCRIPTION
This PR adds fixes a few glitches and add some improvements on the documentation:
- Add lock files (yarn and npm) to .gitignore
- Use Yarn/NPM to run gulp
- Fix some broken links
- Fix the Gulp watcher
- Add some missing illustration (just a blank SVG) to prevent having an empty rectangle on Firefox
