### PR TITLE
Fix a typo in a link in the homepage

### DIFF
--- a/src/index.handlebars
+++ b/src/index.handlebars
@@ -184,7 +184,7 @@
                 <h3 class="text-center">Enterprise Edition Only</h3>
                 <div class="row">
                     <div class="col-xs-12 access-resources">
-                        <a href="/api-reference-index.html#PublishedProducts" class="link-resource">
+                        <a href="/api-reference-index.html#Publishedproducts" class="link-resource">
                             <img class="img-responsive center-block" src="img/illustrations/illus--Publishedproducts.svg"></img>
                             <p class="text-center">Published product</p>
                         </a>


### PR DESCRIPTION
One letter only.