### PR TITLE
Rework client resources organisation

### DIFF
--- a/content/php-client/ce-resources.md
+++ b/content/php-client/ce-resources.md
@@ -1,1 +1,0 @@
-# CE Resources

--- a/content/php-client/ee-resources.md
+++ b/content/php-client/ee-resources.md
@@ -1,1 +1,0 @@
-# EE Resources

--- a/content/php-client/resources/catalog-modeling-entities/association-types.md
+++ b/content/php-client/resources/catalog-modeling-entities/association-types.md
@@ -1,6 +1,6 @@
-## Association type
+### Association type
 
-### Get an association type
+#### Get an association type
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -18,11 +18,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $associationType = $client->getAssociationTypeApi()->get('X_SELL');
 ```
 
-### Get a list of association types
+#### Get a list of association types
 
 There are two ways of getting association types.
  
-#### By getting pages
+**By getting pages**
  
  This method allows to get association types page per page, as a classical pagination.
  
@@ -34,7 +34,7 @@ $firstPage = $client->getAssociationTypeApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the association types. It will automatically get the next pages for you.
 
@@ -46,7 +46,7 @@ $associationTypes = $client->getAssociationTypeApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create an association type
+#### Create an association type
 
 If the association type does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -61,7 +61,7 @@ $client->getAssociationTypeApi()->create('NEW_SELL', [
 ]);
 ```
 
-### Upsert an association type
+#### Upsert an association type
 
 If the association type does not exist yet, this method creates it, otherwise it updates it.
 
@@ -76,7 +76,7 @@ $client->getAssociationTypeApi()->upsert('NEW_SELL', [
 ]);
 ```
 
-### Upsert a list of association types
+#### Upsert a list of association types
 
 This method allows to create or update a list of association types.
 It has the same behavior as the `upsert` method for a single association type, except that the code must be specified in the data of each association type.

--- a/content/php-client/resources/catalog-modeling-entities/attribute-groups.md
+++ b/content/php-client/resources/catalog-modeling-entities/attribute-groups.md
@@ -1,6 +1,6 @@
-## Attribute group
+### Attribute group
 
-### Get an attribute group
+#### Get an attribute group
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -20,11 +20,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $attributeGroup = $client->getAttributeGroupApi()->get('marketing');
 ```
 
-### Get a list of attribute groups
+#### Get a list of attribute groups
 
 There are two ways of getting attribute groups.
  
-#### By getting pages
+**By getting pages**
  
  This method allows to get attribute groups page per page, as a classical pagination.
  
@@ -36,7 +36,7 @@ $firstPage = $client->getAttributeGroupApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the attribute groups. It will automatically get the next pages for you.
 
@@ -48,7 +48,7 @@ $attributeGroups = $client->getAttributeGroupApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create an attribute group
+#### Create an attribute group
 
 If the attribute group does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -64,7 +64,7 @@ $client->getAttributeGroupApi()->create('media', [
 ]);
 ```
 
-### Upsert an attribute group
+#### Upsert an attribute group
 
 If the attribute group does not exist yet, this method creates it, otherwise it updates it.
 
@@ -80,7 +80,7 @@ $client->getAttributeGroupApi()->upsert('marketing', [
 ]);
 ```
 
-### Upsert a list of attribute groups
+#### Upsert a list of attribute groups
 
 This method allows to create or update a list of attribute groups.
 It has the same behavior as the `upsert` method for a single attribute group, except that the code must be specified in the data of each attribute group.

--- a/content/php-client/resources/catalog-modeling-entities/attribute-options.md
+++ b/content/php-client/resources/catalog-modeling-entities/attribute-options.md
@@ -1,6 +1,6 @@
-## Attribute option
+### Attribute option
 
-### Get an attribute option
+#### Get an attribute option
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -20,11 +20,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $attributeOption = $client->getAttributeOptionApi()->get('a_simple_select', 'black');
 ```
 
-### Get a list of attribute options
+#### Get a list of attribute options
 
 There are two ways of getting attribute options. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get attribute options page per page, as a classical pagination.
 
@@ -36,7 +36,7 @@ $firstPage = $client->getAttributeOptionApi()->listPerPage('a_simple_select', 50
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the attribute options. It will automatically get the next pages for you.
 
@@ -48,7 +48,7 @@ $attributes = $client->getAttributeOptionApi()->all('a_simple_select', 50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create an attribute 
+#### Create an attribute 
 
 If the attribute option does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -66,7 +66,7 @@ $client->getAttributeOptionApi()->create('a_simple_select', 'black', [
 ]);
 ```
 
-### Upsert an attribute option
+#### Upsert an attribute option
 
 If the attribute option does not exist yet, this method creates it, otherwise it updates it.
 
@@ -84,7 +84,7 @@ $client->getAttributeOptionApi()->upsert('a_simple_select', 'black', [
 ]);
 ```
 
-### Upsert a list of attribute options
+#### Upsert a list of attribute options
 
 :::warning
 Only available since the version 2.0 of the PHP API client.

--- a/content/php-client/resources/catalog-modeling-entities/attributes.md
+++ b/content/php-client/resources/catalog-modeling-entities/attributes.md
@@ -1,6 +1,6 @@
-## Attribute
+### Attribute
 
-### Get an attribute 
+#### Get an attribute 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -42,11 +42,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $attribute = $client->getAttributeApi()->get('release_date');
 ```
 
-### Get a list of attributes
+#### Get a list of attributes
 
 There are two ways of getting attributes. 
 
-#### By getting page
+**By getting page**
 
 This method allows to get attributes page per page, as a classical pagination.
 It's possible to get the total number of attributes with this method.
@@ -59,7 +59,7 @@ $firstPage = $client->getAttributeApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the attributes. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of attributes.
@@ -72,7 +72,7 @@ $attributes = $client->getAttributeApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create an attribute 
+#### Create an attribute 
 
 If the attribute does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -111,7 +111,7 @@ $client->getAttributeApi()->create('release_date', [
 ]);
 ```
 
-### Upsert an attribute 
+#### Upsert an attribute 
 
 If the attribute does not exist yet, this method creates it, otherwise it updates it.
 
@@ -150,7 +150,7 @@ $client->getAttributeApi()->upsert('release_date', [
 ]);
 ```
 
-### Upsert a list of attributes 
+#### Upsert a list of attributes 
 
 This method allows to create or update a list of attributes.
 It has the same behavior as the `upsert` method for a single attribute, except that the code must be specified in the data of each attribute.

--- a/content/php-client/resources/catalog-modeling-entities/categories.md
+++ b/content/php-client/resources/catalog-modeling-entities/categories.md
@@ -1,6 +1,6 @@
-## Category
+### Category
 
-### Get a category 
+#### Get a category 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -19,11 +19,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $category = $client->getCategoryApi()->get('master');
 ```
 
-### Get a list of categories
+#### Get a list of categories
 
 There are two ways of getting categories. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get categories page per page, as a classical pagination.
 
@@ -35,7 +35,7 @@ $firstPage = $client->getCategoryApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the categories. It will automatically get the next pages for you.
 
@@ -47,7 +47,7 @@ $categories = $client->getCategoryApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create a category
+#### Create a category
 
 If the category does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -63,7 +63,7 @@ $client->getCategoryApi()->create('winter_collection', [
 ]);
 ```
 
-### Upsert a category
+#### Upsert a category
 
 If the category does not exist yet, this method creates it, otherwise it updates it.
 
@@ -79,7 +79,7 @@ $client->getCategoryApi()->upsert('winter_collection', [
 ]);
 ```
 
-### Upsert a list of categories
+#### Upsert a list of categories
 
 This method allows to create or update a list of categories.
 It has the same behavior as the `upsert` method for a single category, except that the code must be specified in the data of each category.

--- a/content/php-client/resources/catalog-modeling-entities/channels.md
+++ b/content/php-client/resources/catalog-modeling-entities/channels.md
@@ -1,6 +1,6 @@
-## Channel
+### Channel
 
-### Get a channel
+#### Get a channel
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -23,11 +23,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $channel = $client->getChannelApi()->get('ecommerce');
 ```
 
-### Get a list of channels
+#### Get a list of channels
 
 There are two ways of getting channels. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get channels page per page, as a classical pagination.
 
@@ -39,7 +39,7 @@ $firstPage = $client->getChannelApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the channels. It will automatically get the next pages for you.
 
@@ -51,7 +51,7 @@ $channels = $client->getChannelApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create a channel
+#### Create a channel
 
 If the channel does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -69,7 +69,7 @@ $client->getChannelApi()->create('paper', [
 ]);
 ```
 
-### Upsert a channel
+#### Upsert a channel
 
 If the channel does not exist yet, this method creates it, otherwise it updates it.
 
@@ -87,7 +87,7 @@ $client->getChannelApi()->upsert('paper', [
 ]);
 ```
 
-### Upsert a list of channels
+#### Upsert a list of channels
 
 This method allows to create or update a list of channels.
 It has the same behavior as the `upsert` method for a single channel, except that the code must be specified in the data of each channel.

--- a/content/php-client/resources/catalog-modeling-entities/families.md
+++ b/content/php-client/resources/catalog-modeling-entities/families.md
@@ -1,6 +1,6 @@
-## Family
+### Family
 
-### Get a family 
+#### Get a family 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -25,11 +25,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $family = $client->getFamilyApi()->get('master');
 ```
 
-### Get a list of families 
+#### Get a list of families 
 
 There are two ways of getting families. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get families page per page, as a classical pagination.
 It's possible to get the total number of families with this method.
@@ -42,7 +42,7 @@ $firstPage = $client->getFamilyApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the families. It will automatically get the next pages for you.
 
@@ -54,7 +54,7 @@ $families = $client->getFamilyApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create a family 
+#### Create a family 
 
 If the family does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -76,7 +76,7 @@ $client->getFamilyApi()->create('caps', [
 ]);
 ```
 
-### Upsert a family 
+#### Upsert a family 
 
 If the family does not exist yet, this method creates it, otherwise it updates it.
 
@@ -98,7 +98,7 @@ $client->getFamilyApi()->upsert('cap', [
 ]);
 ```
 
-### Upsert a list of families 
+#### Upsert a list of families 
 
 This method allows to create or update a list of families.
 It has the same behavior as the `upsert` method for a single family, except that the code must be specified in the data of each family.

--- a/content/php-client/resources/catalog-modeling-entities/family-variants.md
+++ b/content/php-client/resources/catalog-modeling-entities/family-variants.md
@@ -1,6 +1,6 @@
-## Family variants
+### Family variant
 
-### Get a family variant
+#### Get a family variant
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -31,7 +31,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $familyVariant = $client->getFamilyVariantApi()->get('boots', 'boots_color_size');
 ```
 
-### Create a family variant
+#### Create a family variant
 
 If the family variant does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -57,11 +57,11 @@ $client->getFamilyVariantApi()->create('boots', 'boots_size_color', [
 ]);
 ```
 
-### Get a list of family variants
+#### Get a list of family variants
 
 There are two ways of getting family variants.
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get family variants page per page, as a classical pagination.
 It's possible to get the total number of family variants with this method.
@@ -83,7 +83,7 @@ It's recommended to let this parameter with the default value `false` if the tot
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the family variants. It will automatically get the next pages for you.
 
@@ -99,7 +99,7 @@ There is a maximum limit allowed on server side for the parameter `pageSize`.
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Upsert a family variant
+#### Upsert a family variant
 
 If the family variant does not exist yet, this method creates it, otherwise it updates it.
 
@@ -116,7 +116,7 @@ $client->getFamilyVariantApi()->upsert('boots', [
 ]);
 ```
 
-### Upsert a list of family variants
+#### Upsert a list of family variants
 
 This method allows to create or update a list of family variants.
 It has the same behavior as the `upsert` method for a single family variant, except that the code must be specified in the data of each family variant.

--- a/content/php-client/resources/global-settings-entities/currencies.md
+++ b/content/php-client/resources/global-settings-entities/currencies.md
@@ -1,6 +1,6 @@
-## Currency
+### Currency
 
-### Get a currency
+#### Get a currency
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -15,11 +15,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
  $currency = $client->getCurrencyApi()->get('EUR');
 ```
 
-### Get a list of currencies
+#### Get a list of currencies
 
 There are two ways of getting currencies.
  
-#### By getting page
+**By getting page**
 
 This method allows to get currencies page per page, as a classical pagination.
 
@@ -31,7 +31,7 @@ $firstPage = $client->getCurrencyApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the currencies. It will automatically get the next pages for you.
 

--- a/content/php-client/resources/global-settings-entities/locales.md
+++ b/content/php-client/resources/global-settings-entities/locales.md
@@ -1,6 +1,6 @@
-## Locale
+### Locale
 
-### Get a locale 
+#### Get a locale 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -15,11 +15,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $locale = $client->getLocaleApi()->get('ecommerce');
 ```
 
-### Get a list of locales 
+#### Get a list of locales 
 
 There are two ways of getting locales. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get locales page per page, as a classical pagination.
 
@@ -31,7 +31,7 @@ $firstPage = $client->getLocaleApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the locales. It will automatically get the next pages for you.
 

--- a/content/php-client/resources/global-settings-entities/measure-families.md
+++ b/content/php-client/resources/global-settings-entities/measure-families.md
@@ -1,6 +1,6 @@
-## Measure family
+### Measure family
 
-### Get a measure family 
+#### Get a measure family 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -32,11 +32,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $measureFamily = $client->getMeasureFamilyApi()->get('casebox');
 ```
 
-### Get a list of measure families
+#### Get a list of measure families
 
 There are two ways of getting measure families. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get measure families page per page, as a classical pagination.
 
@@ -48,7 +48,7 @@ $firstPage = $client->getMeasureFamilyApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the measure families. It will automatically get the next pages for you.
 

--- a/content/php-client/resources/media-resources-entities/asset-categories.md
+++ b/content/php-client/resources/media-resources-entities/asset-categories.md
@@ -1,4 +1,4 @@
-## Asset categories
+### Asset category
 
 :::warning
 This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
@@ -8,7 +8,7 @@ This resource is only available in the [Entreprise Edition](https://www.akeneo.c
 This resource is only available since the version 2.0 of the PHP API client.
 :::
 
-### Get an asset category
+#### Get an asset category
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -27,11 +27,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $assetCategory = $client->getAssetCategoryApi()->get('face');
 ```
 
-### Get a list of asset categories
+#### Get a list of asset categories
 
 There are two ways of getting asset categories. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get asset categories page per page, as a classical pagination.
 It's possible to get the total number of asset categories with this method.
@@ -44,7 +44,7 @@ $firstPage = $client->getAssetCategoryApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the asset categories. It will automatically get the next pages for you.
 
@@ -56,7 +56,7 @@ $assetCategories = $client->getAssetCategoryApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Upsert an asset category
+#### Upsert an asset category
 
 If the asset category does not exist yet, this method creates it, otherwise it updates it.
 
@@ -72,7 +72,7 @@ $client->getAssetCategoryApi()->upsert('dos', [
 ]);
 ```
 
-### Upsert a list of asset categories
+#### Upsert a list of asset categories
 
 This method allows to create or update a list of asset categories.
 It has the same behavior as the `upsert` method for a single asset category, except that the code must be specified in the data of each asset category.

--- a/content/php-client/resources/media-resources-entities/asset-reference-files.md
+++ b/content/php-client/resources/media-resources-entities/asset-reference-files.md
@@ -1,4 +1,4 @@
-## Asset reference file
+### Asset reference file
 
 :::warning
 This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
@@ -8,7 +8,7 @@ This resource is only available in the [Entreprise Edition](https://www.akeneo.c
 This resource is only available since the version 2.0 of the PHP API client.
 :::
 
-### Get a reference file of a localizable asset
+#### Get a reference file of a localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -28,7 +28,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $product = $client->getAssetReferenceFileApi()->getFromLocalizableAsset('chicagoskyline', 'en_US');
 ```
 
-### Get a reference file of a not localizable asset
+#### Get a reference file of a not localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -48,7 +48,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $product = $client->getAssetReferenceFileApi()->getFromNotLocalizableAsset('bridge');
 ```
 
-### Download a reference file of a localizable asset
+#### Download a reference file of a localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -58,7 +58,7 @@ $product = $client->getAssetReferenceFileApi()->downloadFromLocalizableAsset('ch
 file_put_contents('/tmp/chicagoskyline.jpg', $product->getContents());
 ```
 
-### Download a reference file of a not localizable asset
+#### Download a reference file of a not localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -68,7 +68,7 @@ $product = $client->getAssetReferenceFileApi()->downloadFromNotLocalizableAsset(
 file_put_contents('/tmp/bridge.jpg', $product->getContents());
 ```
 
-### Upload an asset reference file for a localizable asset
+#### Upload an asset reference file for a localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -108,7 +108,7 @@ try {
 
 ```
 
-### Upload an asset reference file for a not localizable asset
+#### Upload an asset reference file for a not localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');

--- a/content/php-client/resources/media-resources-entities/asset-tags.md
+++ b/content/php-client/resources/media-resources-entities/asset-tags.md
@@ -1,4 +1,4 @@
-## Asset tags
+### Asset tag
 
 :::warning
 This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
@@ -8,7 +8,7 @@ This resource is only available in the [Entreprise Edition](https://www.akeneo.c
 This resource is only available since the version 2.0 of the PHP API client.
 :::
 
-### Get an asset tag
+#### Get an asset tag
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -22,11 +22,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $assetTag = $client->getAssetTagApi()->get('water');
 ```
 
-### Get a list of asset tags
+#### Get a list of asset tags
 
 There are two ways of getting asset tags.
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get asset tags page per page, as a classical pagination.
 
@@ -38,7 +38,7 @@ $firstPage = $client->getAssetTagApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the asset tags. It will automatically get the next pages for you.
 
@@ -50,7 +50,7 @@ $assetTags = $client->getAssetTagApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Upsert an asset tag
+#### Upsert an asset tag
 
 If the asset tag does not exist yet, this method creates it, otherwise it updates it.
 

--- a/content/php-client/resources/media-resources-entities/asset-variation-files.md
+++ b/content/php-client/resources/media-resources-entities/asset-variation-files.md
@@ -1,4 +1,4 @@
-## Asset variation file
+### Asset variation file
 
 :::warning
 This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
@@ -8,7 +8,7 @@ This resource is only available in the [Entreprise Edition](https://www.akeneo.c
 This resource is only available since the version 2.0 of the PHP API client.
 :::
 
-### Get a variation file of a localizable asset
+#### Get a variation file of a localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -29,7 +29,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $product = $client->getAssetVariationFileApi()->getFromLocalizableAsset('chicagoskyline', 'mobile', 'en_US');
 ```
 
-### Get a variation file of a not localizable asset
+#### Get a variation file of a not localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -50,7 +50,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $product = $client->getAssetVariationFileApi()->getFromNotLocalizableAsset('bridge', 'mobile');
 ```
 
-### Download a variation file of a localizable asset
+#### Download a variation file of a localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -60,7 +60,7 @@ $product = $client->getAssetVariationFileApi()->downloadFromLocalizableAsset('ch
 file_put_contents('/tmp/chicagoskyline-mobile.jpg', $product->getContents());
 ```
 
-### Download a variation file of a not localizable asset
+#### Download a variation file of a not localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -70,7 +70,7 @@ $product = $client->getAssetVariationFileApi()->downloadFromNotLocalizableAsset(
 file_put_contents('/tmp/bridge-mobile.jpg', $product->getContents());
 ```
 
-### Upload an asset variation file for a localizable asset
+#### Upload an asset variation file for a localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -78,7 +78,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $client->getAssetVariationFileApi()->uploadForLocalizableAsset('/tmp/chicagoskyline-mobile.jpg', 'chicagoskyline', 'mobile','en_US');
 ```
 
-### Upload an asset variation file for a not localizable asset
+#### Upload an asset variation file for a not localizable asset
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');

--- a/content/php-client/resources/media-resources-entities/assets.md
+++ b/content/php-client/resources/media-resources-entities/assets.md
@@ -1,4 +1,4 @@
-## Asset
+### Asset
 
 :::warning
 This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
@@ -8,7 +8,7 @@ This resource is only available in the [Entreprise Edition](https://www.akeneo.c
 This resource is only available since the version 2.0 of the PHP API client.
 :::
 
-### Get an asset 
+#### Get an asset 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -74,11 +74,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimEnterpriseClientBuilder('http://ake
 $asset = $client->getAssetApi()->get('bridge');
 ```
 
-### Get a list of assets 
+#### Get a list of assets 
 
 There are two ways of getting assets. 
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get assets page per page, as a classical pagination.
 It's possible to get the total number of assets with this method.
@@ -91,7 +91,7 @@ $firstPage = $client->getAssetApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the assets. It will automatically get the next pages for you.
 
@@ -103,7 +103,7 @@ $assets = $client->getAssetApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create an asset 
+#### Create an asset 
 
 If the asset does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -119,7 +119,7 @@ $client->getAssetApi()->create('unicorn', [
 ]);
 ```
 
-### Upsert an asset 
+#### Upsert an asset 
 
 If the asset does not exist yet, this method creates it, otherwise it updates it.
 
@@ -135,7 +135,7 @@ $client->getAssetApi()->upsert('bridge', [
 ]);
 ```
 
-### Upsert a list of assets 
+#### Upsert a list of assets 
 
 This method allows to create or update a list of assets.
 It has the same behavior as the `upsert` method for a single asset, except that the code must be specified in the data of each asset.

--- a/content/php-client/resources/media-resources-entities/media-files.md
+++ b/content/php-client/resources/media-resources-entities/media-files.md
@@ -1,6 +1,6 @@
-## Media
+### Media file
 
-### Get media file information
+#### Get media file information
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -23,7 +23,7 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $media = $client->getProductMediaFileApi()->get('code/example');
 ```
 
-### Download media file 
+#### Download media file 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -33,11 +33,11 @@ $mediaFile = $client->getProductMediaFileApi()->download('code/example');
 file_put_contents('/tmp/ziggy.jpg', $product->getContents());
 ```
 
-### Get a list of media file information 
+#### Get a list of media file information 
 
 There are two ways of getting media files.
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get media files page per page, as a classical pagination.
 
@@ -49,7 +49,7 @@ $firstPage = $client->getProductMediaFileApi()->listPerPage(50, true);
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the media files. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of media files.
@@ -63,11 +63,11 @@ $mediaFiles = $client->getProductMediaFileApi()->all(50);
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create a new media file 
+#### Create a new media file 
 
 When you create a media file, you can directly associate it to either a product or a product model.
 
-#### Association to a product
+**Association to a product**
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -80,7 +80,7 @@ $client->getProductMediaFileApi()->create('/tmp/ziggy.jpg', [
 ]);
 ```
 
-#### Association to a product model
+**Association to a product model**
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');

--- a/content/php-client/resources/product-entities/product-drafts.md
+++ b/content/php-client/resources/product-entities/product-drafts.md
@@ -1,6 +1,10 @@
-## Product draft
+### Product draft
 
-### Get a product draft 
+::: warning
+This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
+:::
+
+#### Get a product draft 
 
 ```php
 $client = new \Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -43,7 +47,7 @@ $client = new \Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientBuilder('
  *     ],
  * ]
  */
-$publishedProduct = $client->getProductDraftApi()->get('top');
+$draftProduct = $client->getProductDraftApi()->get('top');
 ```
 
 You can get more information about the returned format of the product values [here](/documentation/resources.html#product-values).
@@ -54,7 +58,7 @@ The field `metadata` is specific to Akeneo PIM Enterprise Edition. The status of
 The field `product_models` in the `associations` property was added in the 2.1 version of the PIM and is therefore not present in previous versions.
 :::
 
-### Submit a product draft for approval
+#### Submit a product draft for approval
 
 ```php
 $client = new \Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');

--- a/content/php-client/resources/product-entities/product-models.md
+++ b/content/php-client/resources/product-entities/product-models.md
@@ -1,6 +1,6 @@
-## Product models
+### Product model
 
-### Get a product model
+#### Get a product model
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -28,11 +28,11 @@ $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')
 $productModel = $client->getProductModelApi()->get('rain_boots_red');
 ```
 
-### Get a list of product models
+#### Get a list of product models
 
 There are two ways of getting product models.
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get product models page per page, as a classical pagination.
 It's possible to get the total number of product models with this method.
@@ -54,7 +54,7 @@ It's recommended to let this parameter with the default value `false` if the tot
 
 You can get more information about this method [here](/php-client/list-resources.html#by-getting-pages).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the product models. It will automatically get the next pages for you.
 
@@ -70,7 +70,7 @@ There is a maximum limit allowed on server side for the parameter `pageSize`.
 
 You can get more information about this method [here](/php-client/list-resources.html#with-a-cursor).
 
-### Create a product model
+#### Create a product model
 
 If the product model does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -102,7 +102,7 @@ $client->getProductModelApi()->create('saddle_rain_boots', [
 
 Product model values use the same format as the product values. If you want to know more, take a look at [here](/documentation/resources.html#product-values).
 
-### Upsert a product model
+#### Upsert a product model
 
 If the product model does not exist yet, this method creates it, otherwise it updates it.
 
@@ -114,7 +114,7 @@ $client->getProductModelApi()->upsert('rain_boots_red', [
 ]);
 ```
 
-### Upsert a list of product models
+#### Upsert a list of product models
 
 This method allows to create or update a list of product models.
 It has the same behavior as the `upsert` method for a single product model, except that the code must be specified in the data of each product models.

--- a/content/php-client/resources/product-entities/products.md
+++ b/content/php-client/resources/product-entities/products.md
@@ -1,6 +1,6 @@
-## Product
+### Product
 
-### Get a product 
+#### Get a product 
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -52,11 +52,11 @@ In the Enterprise Edition, the response contains one more field `metadata`. Look
 The field `product_models` in the `associations` property was added in the 2.1 version of the PIM and is therefore not present in previous versions.
 :::
 
-### Get a list of products 
+#### Get a list of products
 
 There are two ways of getting products. Also, you have a search builder to ease the construction of a research.
 
-#### Search builder
+**Search builder**
 
 You can search over the products, thanks to a list of filters.
 An helper has been added to ease the construction of these filters.
@@ -75,7 +75,7 @@ $searchBuilder
 $searchFilters = $searchBuilder->getFilters();
 ```
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get products page per page, as a classical pagination. You can research products thanks to the search builder.
 
@@ -110,7 +110,7 @@ You can get more information about this method [here](/php-client/list-resources
 
 You can get more information about the available query parameters [here](/api-reference.html#get_products).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the products. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of products.
@@ -139,7 +139,7 @@ You can get more information about this method [here](/php-client/list-resources
 
 You can get more information about the available query parameters [here](/api-reference.html#get_products).
 
-### Create a product 
+#### Create a product 
 
 If the product does not exist yet, this method creates it, otherwise it throws an exception.
 
@@ -187,7 +187,7 @@ $client->getProductApi()->create('top', [
 
 You can get more information about the expected format of the product values [here](/documentation/resources.html#product-values).
 
-### Upsert a product 
+#### Upsert a product 
 
 If the product does not exist yet, this method creates it, otherwise it updates it.
 
@@ -240,7 +240,7 @@ If you are using a v2.0 Entreprise Edition PIM, permissions based on your user g
 If you have edit rights but do not own the product, then it will create a [product draft](/php-client/ee-resources.html#product-draft) instead of updating the product.
 :::
 
-### Upsert a list of products 
+#### Upsert a list of products 
 
 This method allows to create or update a list of products.
 It has the same behavior as the `upsert` method for a single product, except that the code must be specified in the data of each product.
@@ -296,7 +296,7 @@ There is a limit on the maximum number of products that you can upsert in one ti
 
 You can get a complete description of the expected format and the returned format [here](/api-reference.html#get_products__code_).
 
-### Delete a product
+#### Delete a product
 
 ```php
 $client = new \Akeneo\Pim\ApiClient\AkeneoPimClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');

--- a/content/php-client/resources/product-entities/published-products.md
+++ b/content/php-client/resources/product-entities/published-products.md
@@ -1,6 +1,10 @@
-## Published product
+### Published product
 
-### Get a published product 
+::: warning
+This resource is only available in the [Entreprise Edition](https://www.akeneo.com/enterprise-edition/).
+:::
+
+#### Get a published product 
 
 ```php
 $client = new \Akeneo\PimEnterprise\ApiClient\AkeneoPimEnterpriseClientBuilder('http://akeneo.com/')->buildAuthenticatedByPassword('client_id', 'secret', 'admin', 'admin');
@@ -49,11 +53,11 @@ You can get more information about the returned format of the product values [he
 The field `product_models` in the `associations` property was added in the 2.1 version of the PIM and is therefore not present in previous versions.
 :::
 
-### Get a list of published products 
+#### Get a list of published products
 
 There are two ways of getting published products. Like for the products, you can use the [search builder](/php-client/ce-resources.html#search-builder) to ease the construction of a research.
 
-#### By getting pages
+**By getting pages**
 
 This method allows to get published products page per page, as a classical pagination. You can research published products thanks to the search builder.
 
@@ -88,7 +92,7 @@ You can get more information about this method [here](/php-client/list-resources
 
 You can get more information about the available query parameters [here](/api-reference.html#get_published_products).
 
-#### With a cursor
+**With a cursor**
 
 This method allows to iterate the published products. It will automatically get the next pages for you.
 With this method, it's not possible to get the previous page, or getting the total number of published products.


### PR DESCRIPTION
The menu of client resources was too long. On some small screen, the end of the menu was not even accessible.
This PR reorganises it in several main sections for better readability.

**Before**
![screen shot 2018-01-12 at 17 08 07](https://user-images.githubusercontent.com/25225430/34883864-33e3754a-f7bb-11e7-9be3-f17ea2304988.png)


**After**
![screen shot 2018-01-12 at 17 06 32](https://user-images.githubusercontent.com/25225430/34883796-fdec2d2e-f7ba-11e7-892b-d062b46bbc76.png)
