### PR TITLE
Add product models association to product and fix hbls template

### DIFF
--- a/content/swagger/definitions.yaml
+++ b/content/swagger/definitions.yaml
@@ -185,7 +185,7 @@ ErrorByLine:
       description: Resource identifier, only filled when the resource is a product
     code:
       type: string
-      description: Resource code, only filled when the resource is a category, a family or an attribute
+      description: Resource code, only filled when the resource is not a product
     status_code:
       type: integer
       description: HTTP status code, see <a href="/documentation/responses.html#client-errors">Client errors</a> to understand the meaning of each code

--- a/content/swagger/resources/products/definitions/product.yaml
+++ b/content/swagger/resources/products/definitions/product.yaml
@@ -29,7 +29,7 @@ properties:
     default: []
   parent:
     type: string
-    description: Code of the parent product model when the product is a variant (only available in 2.x)
+    description: Code of the parent product model when the product is a variant (only available since the 2.0)
     x-validation-rules: It is equal to an existing product model code only if the product is variant otherwise it's equal to null
     default: "null"
     x-immutable: true
@@ -70,6 +70,11 @@ properties:
             description: Array of product identifiers with which the product is in relation
             items:
               type: string
+          product_models:
+            type: array
+            description: Array of product model codes with which the product is in relation (only available since the v2.1)
+            items:
+              type: string
   created:
     type: string
     description: Date of creation
@@ -83,12 +88,12 @@ properties:
     x-read-only: true
   metadata:
     type: object
-    description: More information around the product (only available in the v2.x Enterprise Edition)
+    description: More information around the product (only available since the v2.0 in the Enterprise Edition)
     x-immutable: true
     x-read-only: true
     properties:
       workflow_status:
-        description: Status of the product regarding the user permissions (only available in the v2.x Enterprise Edition)
+        description: Status of the product regarding the user permissions (only available since the v2.0 in the Enterprise Edition)
         type: string
         enum: ['read_only','draft_in_progress','proposal_waiting_for_approval','working_copy']
     
@@ -168,7 +173,7 @@ example: {
   "associations": {
     "PACK": {
       "products": ["sunglass"],
-       "groups": []
+      "groups": []
     }
   }
 }

--- a/content/swagger/resources/published_products/definitions/published_product.yaml
+++ b/content/swagger/resources/published_products/definitions/published_product.yaml
@@ -64,6 +64,11 @@ properties:
             description: Array of published product identifiers with which the published product is in relation
             items:
               type: string
+          product_models:
+            type: array
+            description: Array of product model codes with which the product is in relation (only available since the v2.1)
+            items:
+              type: string
   created:
     type: string
     description: Date of creation

--- a/src/api-reference/reference.handlebars
+++ b/src/api-reference/reference.handlebars
@@ -414,6 +414,7 @@
                                                                                 <br> &nbsp; }
                                                                                 {{else}}
                                                                                     {{#with items}}
+                                                                                        {{#if properties}}
                                                                                                 : [ <br> &nbsp; &nbsp; &nbsp; &nbsp; { <br>
                                                                                                         {{#each properties}}
                                                                                                             &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
@@ -433,6 +434,9 @@
                                                                                                             {{/if}}
                                                                                                         {{/each}}
                                                                                                     &nbsp; &nbsp; &nbsp; &nbsp; } <br> &nbsp; &nbsp; ]
+                                                                                        {{else}}
+                                                                                            &bull; {{{../description}}}
+                                                                                        {{/if}}
                                                                                     {{else}}
                                                                                         &bull; {{{description}}}
                                                                                     {{/with}}
@@ -463,9 +467,9 @@
                                                                                                                             {{#each properties}}
                                                                                                                                 &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp;
                                                                                                                                 <code>{{{@key}}}</code>
-                                                                                                                                <em>({{{type}}}{{#if items}} [{{{items.type}}} ]{{/if}} )</em> &bull; {{{description}}}{{#unless @last}} <br> {{/unless}} <br>
+                                                                                                                                <em>({{{type}}}{{#if items}} [{{{items.type}}} ]{{/if}} )</em> &bull; {{{description}}}{{#unless @last}} <br> {{/unless}}
                                                                                                                             {{/each}}
-                                                                                                                            &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; } {{#unless @last}} <br> {{/unless}}
+                                                                                                                            <br>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; } {{#unless @last}} <br> {{/unless}}
                                                                                                                         {{else}}
                                                                                                                             {{#with items}}
                                                                                                                                 {{#if properties}} : [ <br> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; { <br>
@@ -484,7 +488,7 @@
                                                                                                                     {{/each}}
                                                                                                                     <br> &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; } <br>
                                                                                                                 {{else}}
-                                                                                                                    &bull; {{{description}}} <br>
+                                                                                                                    &bull; {{{description}}}<br>
                                                                                                                 {{/if}}
                                                                                                             {{/each}}
                                                                                                         {{/each}}

--- a/src/getting-started.handlebars
+++ b/src/getting-started.handlebars
@@ -132,11 +132,13 @@
   <span class="hljs-attr">"associations"</span>: {
     <span class="hljs-attr">"pack"</span>: {
       <span class="hljs-attr">"groups"</span>: [],
-      <span class="hljs-attr">"products"</span>: [<span class="hljs-string">"product_identifier_1"</span>,<span class="hljs-string">"product_identifier_2"</span>]
+      <span class="hljs-attr">"products"</span>: [<span class="hljs-string">"product_identifier_1"</span>,<span class="hljs-string">"product_identifier_2"</span>],
+      <span class="hljs-attr">"product_models"</span>: []
      },
      <span class="hljs-attr">"x_sell"</span>: {
        <span class="hljs-attr">"groups"</span>: [],
-       <span class="hljs-attr">"products"</span>: []
+       <span class="hljs-attr">"products"</span>: [],
+      <span class="hljs-attr">"product_models"</span>: []
      }
   }
 }


### PR DESCRIPTION
Since the 2.1, we have a new key in the `associations` property of the product.

And some fixes of issues I spotted in the hbls template of the reference as well as the swagger spec