### PR TITLE
Draft creation and metadata are new in PM since 2.3

### DIFF
--- a/content/rest-api/resources.md
+++ b/content/rest-api/resources.md
@@ -793,7 +793,7 @@ Note that the `parent` field is only available in the 2.x versions, as this is a
 :::
 
 ::: warning
-Note that the `metadata` field in only available in the 2.x versions and as it is an Enterprise Edition feature, you won't have this field on a Community Edition PIM.
+Note that the `metadata` field is only available in the 2.x versions and as it is an Enterprise Edition feature, you won't have this field on a Community Edition PIM.
 :::
 
 ::: panel-link Want more details about the product resource? [Check its endpoints here!](/api-reference.html#Products)
@@ -1002,12 +1002,19 @@ To finish, below is the JSON standard format representing a product model. Notic
     ]
   },
   "created": "2017-10-05T11:24:46+02:00",
-  "updated": "2017-10-05T11:24:46+02:00"
+  "updated": "2017-10-05T11:24:46+02:00",
+  "metadata": {
+    "workflow_status": "working_copy"
+  }
 }
 ```
 
 ::: warning
 Endpoints for the product models are only available starting the 2.0 version.
+:::
+
+::: warning
+Note that the `metadata` field is only available since the 2.3 version and as it is an Enterprise Edition feature, you won't have this field on a Community Edition PIM.
 :::
 
 ::: panel-link Want more details about the product model resource? [Check its endpoints here!](/api-reference.html#Productmodels)

--- a/content/swagger/resources/product_models/routes/product_models.yaml
+++ b/content/swagger/resources/product_models/routes/product_models.yaml
@@ -7,7 +7,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to get a list of product models. Product models are paginated.
+  description: This endpoint allows you to get a list of product models. Product models are paginated. In the Enterprise Edition, since the 2.0, permissions based on your user groups are applied to the set of products you request.
   parameters:
     - $ref: '#/parameters/pagination_type'
     - $ref: '#/parameters/page'
@@ -164,7 +164,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to create a new product model.
+  description: This endpoint allows you to create a new product model. In the Enterprise Edition, since the v2.3, permissions based on your user groups are applied to the product model you try to create.
   parameters:
     - name: body
       in: body
@@ -190,7 +190,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to update and/or create several product models at once. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product models exists for the given code, it creates it.
+  description: This endpoint allows you to update and/or create several product models at once. Learn more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product models exists for the given code, it creates it. In the Enterprise Edition, since the v2.3, permissions based on your user groups are applied to the product models you try to update. It may result in the creation of drafts if you only have edit rights through the product model's categories.
   x-body-by-line: Contains several lines, each line is a product model in JSON standard format
   parameters:
     - name: body

--- a/content/swagger/resources/product_models/routes/product_models_code.yaml
+++ b/content/swagger/resources/product_models/routes/product_models_code.yaml
@@ -7,7 +7,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to get the information about a given product model.
+  description: This endpoint allows you to get the information about a given product model. In the Entreprise Edition, since the v2.0, permissions based on your user groups are applied to the product model you request.
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -31,7 +31,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to update a given product model. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product model exists for the given code, it creates it.
+  description: This endpoint allows you to update a given product model. Learn more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product model exists for the given code, it creates it. In the Enterprise Edition PIM since the 2.3, permissions based on your user groups are applied to the product model you try to update. It may result in the creation of a draft if you only have edit rights through the product model's categories.
   parameters:
     - $ref: '#/parameters/code'
     - name: body

--- a/content/swagger/resources/products/routes/products.yaml
+++ b/content/swagger/resources/products/routes/products.yaml
@@ -8,7 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to get a list of products. Products are paginated and they can be filtered. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the set of products you request.
+  description: This endpoint allows you to get a list of products. Products are paginated and they can be filtered. In the Enterprise Edition, since the 2.0, permissions based on your user groups are applied to the set of products you request.
   parameters:
     - name: search
       in: query
@@ -271,7 +271,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to create a new product. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you try to create.
+  description: This endpoint allows you to create a new product. In the Enterprise Edition, since the v2.0, permissions based on your user groups are applied to the product you try to create.
   parameters:
     - name: body
       in: body
@@ -300,7 +300,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to update and/or create several products at once. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product exists for the given identifier, it creates it. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the products you try to update. It may result in the creation of drafts if you only have edit rights through the product's categories.
+  description: This endpoint allows you to update and/or create several products at once. Learn more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product exists for the given identifier, it creates it. In the Enterprise Edition, since the v2.0, permissions based on your user groups are applied to the products you try to update. It may result in the creation of drafts if you only have edit rights through the product's categories.
   x-body-by-line: Contains several lines, each line is a product in JSON standard format
   parameters:
     - name: body

--- a/content/swagger/resources/products/routes/products_code.yaml
+++ b/content/swagger/resources/products/routes/products_code.yaml
@@ -8,7 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to get the information about a given product. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you request.
+  description: This endpoint allows you to get the information about a given product. In the Entreprise Edition, since the v2.0, permissions based on your user groups are applied to the product you request.
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -35,7 +35,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to update a given product. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product exists for the given identifier, it creates it. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you try to update. It may result in the creation of a draft if you only have edit rights through the product's categories.
+  description: This endpoint allows you to update a given product. Learn more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product exists for the given identifier, it creates it. In the Entreprise Edition, since the v2.0, permissions based on your user groups are applied to the product you try to update. It may result in the creation of a draft if you only have edit rights through the product's categories.
   parameters:
     - $ref: '#/parameters/code'
     - name: body
@@ -66,7 +66,7 @@ delete:
     - "2.0"
     - "2.1"
     - "2.2"
-  description: This endpoint allows you to delete a given product. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you try to delete.
+  description: This endpoint allows you to delete a given product. In the Enterprise Edition, since the 2.0, permissions based on your user groups are applied to the product you try to delete.
   parameters:
     - $ref: '#/parameters/code'
   responses:


### PR DESCRIPTION
In Swagger:
- Add description to say that user groups permissions are now applied on product models.
- Add description to say that in some cases, you might create draft when updating product models.

In Resources section of the plain API doc:
- Add the metadata field which is new into the product model format.