### PR TITLE
Add the 2.3 version on all endpoints in Swagger

### DIFF
--- a/content/swagger/resources/asset_categories/routes/asset_categories.yaml
+++ b/content/swagger/resources/asset_categories/routes/asset_categories.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/page'
@@ -106,6 +107,7 @@ post:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - name: body
@@ -133,6 +135,7 @@ patch:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   description: This endpoint allows you to update several asset categories at once.
   x-body-by-line: Contains several lines, each line is a category in JSON standard format

--- a/content/swagger/resources/asset_categories/routes/asset_categories_code.yaml
+++ b/content/swagger/resources/asset_categories/routes/asset_categories_code.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/code'
@@ -32,6 +33,7 @@ patch:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   description: This endpoint allows you to update a given asset category. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no category exists for the given code, it creates it.
   parameters:

--- a/content/swagger/resources/asset_tags/routes/asset_tags.yaml
+++ b/content/swagger/resources/asset_tags/routes/asset_tags.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/page'

--- a/content/swagger/resources/asset_tags/routes/asset_tags_code.yaml
+++ b/content/swagger/resources/asset_tags/routes/asset_tags_code.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/code'
@@ -32,6 +33,7 @@ patch:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   description: This endpoint allows you to update a given asset tag. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no tag exists for the given code, it creates it.
   parameters:

--- a/content/swagger/resources/assets/routes/assets.yaml
+++ b/content/swagger/resources/assets/routes/assets.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/pagination_type'
@@ -214,6 +215,7 @@ post:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - name: body
@@ -241,6 +243,7 @@ patch:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   description: This endpoint allows you to update several assets at once.
   x-body-by-line: Contains several lines, each line is an asset in JSON format

--- a/content/swagger/resources/assets/routes/assets_code.yaml
+++ b/content/swagger/resources/assets/routes/assets_code.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/code'
@@ -32,6 +33,7 @@ patch:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   description: This endpoint allows you to update a given asset. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no asset exists for the given code, it creates it.
   parameters:

--- a/content/swagger/resources/assets/routes/assets_code_reference_files_channel_code_locale_code.yaml
+++ b/content/swagger/resources/assets/routes/assets_code_reference_files_channel_code_locale_code.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/asset_code'
@@ -34,6 +35,7 @@ post:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/asset_code'

--- a/content/swagger/resources/assets/routes/assets_code_reference_files_channel_code_locale_code_download.yaml
+++ b/content/swagger/resources/assets/routes/assets_code_reference_files_channel_code_locale_code_download.yaml
@@ -8,6 +8,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/asset_code'

--- a/content/swagger/resources/assets/routes/assets_code_variation_files_channel_code_locale_code.yaml
+++ b/content/swagger/resources/assets/routes/assets_code_variation_files_channel_code_locale_code.yaml
@@ -7,6 +7,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/asset_code'
@@ -35,6 +36,7 @@ post:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/asset_code'

--- a/content/swagger/resources/assets/routes/assets_code_variation_files_channel_code_locale_code_download.yaml
+++ b/content/swagger/resources/assets/routes/assets_code_variation_files_channel_code_locale_code_download.yaml
@@ -8,6 +8,7 @@ get:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   x-ee: true
   parameters:
     - $ref: '#/parameters/asset_code'

--- a/content/swagger/resources/association_types/routes/association_types.yaml
+++ b/content/swagger/resources/association_types/routes/association_types.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -95,6 +96,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: body
       in: body
@@ -122,6 +124,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several association types at once.
   x-body-by-line: Contains several lines, each line is an association type in JSON standard format
   parameters:

--- a/content/swagger/resources/association_types/routes/association_types_code.yaml
+++ b/content/swagger/resources/association_types/routes/association_types_code.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -33,6 +34,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given association type. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no association type exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/attribute_groups/routes/attribute_groups.yaml
+++ b/content/swagger/resources/attribute_groups/routes/attribute_groups.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -110,6 +111,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: body
       in: body
@@ -137,6 +139,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several attribute groups at once.
   x-body-by-line: Contains several lines, each line is an attribute group in JSON standard format
   parameters:

--- a/content/swagger/resources/attribute_groups/routes/attribute_groups_code.yaml
+++ b/content/swagger/resources/attribute_groups/routes/attribute_groups_code.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -33,6 +34,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given attribute group. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no attribute group exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/attributes/routes/attributes.yaml
+++ b/content/swagger/resources/attributes/routes/attributes.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -139,6 +140,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: body
       in: body
@@ -167,6 +169,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several attributes at once.
   x-body-by-line: Contains several lines, each line is an attribute in JSON standard format
   parameters:

--- a/content/swagger/resources/attributes/routes/attributes_code.yaml
+++ b/content/swagger/resources/attributes/routes/attributes_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -35,6 +36,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given attribute. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no attribute exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/attributes/routes/attributes_code_options.yaml
+++ b/content/swagger/resources/attributes/routes/attributes_code_options.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/attribute_code'
     - $ref: '#/parameters/page'
@@ -110,6 +111,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/attribute_code'
     - name: body
@@ -137,6 +139,7 @@ patch:
   x-versions:
     - 2.1
     - 2.2
+    - 2.3
   description: This endpoint allows you to update several attribute options at once.
   x-body-by-line: Contains several lines, each line is an attribute option in JSON standard format
   parameters:

--- a/content/swagger/resources/attributes/routes/attributes_code_options_code.yaml
+++ b/content/swagger/resources/attributes/routes/attributes_code_options_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/attribute_code'
     - $ref: '#/parameters/code'
@@ -36,6 +37,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given attribute option. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no attribute option exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/attribute_code'

--- a/content/swagger/resources/categories/routes/categories.yaml
+++ b/content/swagger/resources/categories/routes/categories.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -137,6 +138,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: body
       in: body
@@ -165,6 +167,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update several categories at once.
   x-body-by-line: Contains several lines, each line is a category in JSON standard format
   parameters:

--- a/content/swagger/resources/categories/routes/categories_code.yaml
+++ b/content/swagger/resources/categories/routes/categories_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -35,6 +36,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given category. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no category exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/channels/routes/channels.yaml
+++ b/content/swagger/resources/channels/routes/channels.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -119,6 +120,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: body
       in: body
@@ -146,6 +148,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several channels at once.
   x-body-by-line: Contains several lines, each line is a channel in JSON standard format
   parameters:

--- a/content/swagger/resources/channels/routes/channels_code.yaml
+++ b/content/swagger/resources/channels/routes/channels_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -34,6 +35,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given channel. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no channel exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/currencies/routes/currencies.yaml
+++ b/content/swagger/resources/currencies/routes/currencies.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'

--- a/content/swagger/resources/currencies/routes/currencies_code.yaml
+++ b/content/swagger/resources/currencies/routes/currencies_code.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:

--- a/content/swagger/resources/families/routes/families.yaml
+++ b/content/swagger/resources/families/routes/families.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -105,6 +106,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: body
       in: body
@@ -133,6 +135,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several families at once.
   x-body-by-line: Contains several lines, each line is a family in JSON standard format
   parameters:

--- a/content/swagger/resources/families/routes/families_code.yaml
+++ b/content/swagger/resources/families/routes/families_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:
@@ -35,6 +36,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given family. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no family exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/families/routes/families_code_variants.yaml
+++ b/content/swagger/resources/families/routes/families_code_variants.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/family_code'
     - $ref: '#/parameters/page'
@@ -63,6 +64,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to create a family variant.
   parameters:
     - $ref: '#/parameters/family_code'
@@ -92,6 +94,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several family variants at once, for a given family.
   x-body-by-line: Contains several lines, each line is a family in JSON standard format
   parameters:

--- a/content/swagger/resources/families/routes/families_code_variants_code.yaml
+++ b/content/swagger/resources/families/routes/families_code_variants_code.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/family_code'
     - $ref: '#/parameters/code'
@@ -34,6 +35,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given family variant. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no family variant exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/family_code'

--- a/content/swagger/resources/list_endpoints.yaml
+++ b/content/swagger/resources/list_endpoints.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   x-no-token: true
   responses:
     200:

--- a/content/swagger/resources/locales/routes/locales.yaml
+++ b/content/swagger/resources/locales/routes/locales.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'

--- a/content/swagger/resources/locales/routes/locales_code.yaml
+++ b/content/swagger/resources/locales/routes/locales_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:

--- a/content/swagger/resources/measure_families/routes/measure_families.yaml
+++ b/content/swagger/resources/measure_families/routes/measure_families.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   responses:
     200:
       description: Return measure families paginated

--- a/content/swagger/resources/measure_families/routes/measure_families_code.yaml
+++ b/content/swagger/resources/measure_families/routes/measure_families_code.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:

--- a/content/swagger/resources/media_files/routes/media_files.yaml
+++ b/content/swagger/resources/media_files/routes/media_files.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/page'
     - $ref: '#/parameters/limit'
@@ -127,6 +128,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - name: Content-type
       in: header

--- a/content/swagger/resources/media_files/routes/media_files_code.yaml
+++ b/content/swagger/resources/media_files/routes/media_files_code.yaml
@@ -9,6 +9,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:

--- a/content/swagger/resources/media_files/routes/media_files_code_download.yaml
+++ b/content/swagger/resources/media_files/routes/media_files_code_download.yaml
@@ -10,6 +10,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   parameters:
     - $ref: '#/parameters/code'
   responses:

--- a/content/swagger/resources/product_models/routes/product_models.yaml
+++ b/content/swagger/resources/product_models/routes/product_models.yaml
@@ -7,6 +7,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to get a list of product models. Product models are paginated.
   parameters:
     - $ref: '#/parameters/pagination_type'
@@ -164,6 +165,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to create a new product model.
   parameters:
     - name: body
@@ -190,6 +192,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several product models at once. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product models exists for the given code, it creates it.
   x-body-by-line: Contains several lines, each line is a product model in JSON standard format
   parameters:

--- a/content/swagger/resources/product_models/routes/product_models_code.yaml
+++ b/content/swagger/resources/product_models/routes/product_models_code.yaml
@@ -7,6 +7,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to get the information about a given product model.
   parameters:
     - $ref: '#/parameters/code'
@@ -31,6 +32,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given product model. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product model exists for the given code, it creates it.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/products/routes/products.yaml
+++ b/content/swagger/resources/products/routes/products.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to get a list of products. Products are paginated and they can be filtered. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the set of products you request.
   parameters:
     - name: search
@@ -271,6 +272,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to create a new product. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you try to create.
   parameters:
     - name: body
@@ -300,6 +302,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update and/or create several products at once. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product exists for the given identifier, it creates it. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the products you try to update. It may result in the creation of drafts if you only have edit rights through the product's categories.
   x-body-by-line: Contains several lines, each line is a product in JSON standard format
   parameters:

--- a/content/swagger/resources/products/routes/products_code.yaml
+++ b/content/swagger/resources/products/routes/products_code.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to get the information about a given product. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you request.
   parameters:
     - $ref: '#/parameters/code'
@@ -35,6 +36,7 @@ patch:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to update a given product. Know more about <a href="/documentation/update.html#update-behavior">Update behavior</a>. Note that if no product exists for the given identifier, it creates it. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you try to update. It may result in the creation of a draft if you only have edit rights through the product's categories.
   parameters:
     - $ref: '#/parameters/code'
@@ -66,6 +68,7 @@ delete:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   description: This endpoint allows you to delete a given product. If you are using a v2.0 Enterprise Edition PIM, permissions based on your user groups are applied to the product you try to delete.
   parameters:
     - $ref: '#/parameters/code'

--- a/content/swagger/resources/products/routes/products_code_draft.yaml
+++ b/content/swagger/resources/products/routes/products_code_draft.yaml
@@ -7,6 +7,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   x-ee: true
   description: This endpoint allows you to get the information about a given draft.
   parameters:

--- a/content/swagger/resources/products/routes/products_code_proposal.yaml
+++ b/content/swagger/resources/products/routes/products_code_proposal.yaml
@@ -7,6 +7,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   x-ee: true
   description: This endpoint allows you to submit a draft for approval.
   parameters:

--- a/content/swagger/resources/published_products/routes/published_products.yaml
+++ b/content/swagger/resources/published_products/routes/published_products.yaml
@@ -8,6 +8,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   x-ee: true
   parameters:
     - name: search

--- a/content/swagger/resources/published_products/routes/published_products_code.yaml
+++ b/content/swagger/resources/published_products/routes/published_products_code.yaml
@@ -7,6 +7,7 @@ get:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   x-ee: true
   description: This endpoint allows you to get the information about a given published product.
   parameters:

--- a/content/swagger/resources/token.yaml
+++ b/content/swagger/resources/token.yaml
@@ -9,6 +9,7 @@ post:
     - "2.0"
     - "2.1"
     - "2.2"
+    - "2.3"
   x-no-token: true
   parameters:
     - name: Content-type


### PR DESCRIPTION
I hesitated to put 2.x instead of the complete list "2.0, 2.1, 2.2, 2.3" when the endpoint is working in all 2.x versions. But I will wait for the 3.0 release I think to switch to this format.