### PR TITLE
Make the default env conf fit with the demo env conf

### DIFF
--- a/content/files/Akeneo PIM API environment.postman_environment.json
+++ b/content/files/Akeneo PIM API environment.postman_environment.json
@@ -4,19 +4,19 @@
     {
       "enabled": true,
       "key": "url",
-      "value": "http://my-favorite-pim.com",
+      "value": "http://demo.akeneo.com",
       "type": "text"
     },
     {
       "enabled": true,
       "key": "clientId",
-      "value": "1_4o4k6z2ydcisokg40ggssgogc8ws4kogoo888ocswkkckc0woo",
+      "value": "1_demo_client_id",
       "type": "text"
     },
     {
       "enabled": true,
       "key": "secret",
-      "value": "3l6sukxg1f28so0ws4ss44cwsow0w44c4kgkwsosww88scckkc",
+      "value": "demo_secret",
       "type": "text"
     },
     {


### PR DESCRIPTION
Related to ASS'2018, Team 'Making ECS happy'
Expected outcome: Akeneo API users can test Akeneo API without setting up a whole PIM instance. Using demo.akeno.com

The demo.akeneo.com have a default API connection (see https://github.com/akeneo/ansible/pull/464).
Current PR aligns the proposed Environment `.json` template file according to that default API connection.
