### PR TITLE
Remove outdated warning about localizable attributes

### DIFF
--- a/content/rest-api/resources.md
+++ b/content/rest-api/resources.md
@@ -177,10 +177,6 @@ Some attributes can be shown only for specific locales. We will call them locale
 
 Finally, an attribute can be scopable. An attribute is scopable if its values differ for each channel. For instance, you might have one short description for your e-commerce website, maybe one even shorter for your mobile app but a long one for your print catalog.
 
-:::warning
-An attribute cannot be both localizable and locale specific at the same time.
-:::
-
 In the Akeneo UI, you can find the attributes in the `Settings`/`Attributes` menu. Below is an example of one attribute in the UI.
 
 ::: versions id="attributes" 2.x![Attributes in the Akeneo UI](/img/screenshots/v2.0/attributes_ui.png) 1.7![Attributes in the Akeneo UI](/img/screenshots/v1.7/attributes_ui.png)


### PR DESCRIPTION
I'm proposing to remove the warning `An attribute cannot be both localizable and locale specific at the same time.` 
Presumably this statement was valid for earlier Akeneo versions, but with 2.3 you can have an attribute that is both localizable and locale specific.

![image](https://user-images.githubusercontent.com/6177375/48125220-7adf2080-e27e-11e8-94b8-3e1a96d9212b.png)

Another option would be to change the text to 'An attribute **can** be both localizable and locale specific at the same time.', but I see no value in this statement, it seems to be intuitive. 