### PR TITLE
Add new attribute types

### DIFF
--- a/content/rest-api/resources.md
+++ b/content/rest-api/resources.md
@@ -1136,7 +1136,8 @@ Below is the JSON standard format representing a reference entity attribute.
   "is_textarea": true,
   "is_rich_text_editor": true,
   "validation_rule": null,
-  "validation_regexp": null
+  "validation_regexp": null,
+  "reference_entity_code": null
 }
 ```
 

--- a/content/swagger/resources/reference_entity_attributes/definitions/reference_entity_attribute.yaml
+++ b/content/swagger/resources/reference_entity_attributes/definitions/reference_entity_attribute.yaml
@@ -17,7 +17,7 @@ properties:
   type:
     type: string
     description: Attribute type
-    enum: ['text', 'image']
+    enum: ['text', 'image', 'single_option', 'multiple_options', 'reference_entity_single_link', 'reference_entity_multiple_links']
   localizable:
     type: boolean
     description: Whether the attribute is localizable, i.e. can have one value by locale
@@ -47,7 +47,7 @@ properties:
     description: Validation rule type used to validate the attribute value when the attribute type is `text`
     default : null
     x-warning: Only for `text` attribute type
-    enum: ['email','url','regexp', null]
+    enum: ['email', 'url', 'regexp', null]
   validation_regexp:
     type: string
     description: Regexp expression used to validate the attribute value when the attribute type is `text`
@@ -66,6 +66,11 @@ properties:
     description: Max file size in MB when the attribute type is `image`
     default : null
     x-warning: Only for `image` attribute type
+  reference_entity_code:
+    type: string
+    description: Code of the linked reference entity when the attribute type is `reference_entity_single_link` or `reference_entity_multiple_links`
+    default : null
+    x-warning: Only for `reference_entity_single_link` and `reference_entity_multiple_links` attribute type
 example: {
   "code": "description",
   "labels": {
@@ -79,5 +84,6 @@ example: {
   "is_textarea": true,
   "is_rich_text_editor": true,
   "validation_rule": null,
-  "validation_regexp": null
+  "validation_regexp": null,
+  "reference_entity_code": null
 }

--- a/content/swagger/resources/reference_entity_attributes/routes/reference_entity_attributes.yaml
+++ b/content/swagger/resources/reference_entity_attributes/routes/reference_entity_attributes.yaml
@@ -50,11 +50,7 @@ get:
           "type": "text",
           "localizable": true,
           "scopable": false,
-          "max_characters": 100,
-          "is_textarea": false,
-          "is_rich_text_editor": null,
-          "validation_rule": null,
-          "validation_regexp": null
+          "reference_entity_code": null
         },
         {
           "_links": {


### PR DESCRIPTION
There are four new attribute types in the ref entities now:
- single option,
- multiple options,
- reference entity single link,
- reference entity multiple links.

I added these new types into the format specification of the ref entity attribute. There is a new field called `reference_entity_code` when the type is either `reference entity single link` and `reference entity multiple links`.