### PR TITLE
Fix get a token request that cause invalid json response

### DIFF
--- a/content/rest-api/security.md
+++ b/content/rest-api/security.md
@@ -154,8 +154,8 @@ curl -X POST http://your-host/api/oauth/v1/token \
     -H "Authorization: Basic YOUR_BASE_64_CLIENT_ID_AND_SECRET" \
     -d '{
         "grant_type": "password",
-        "username": your_username,
-        "password": your_password
+        "username": "your_username",
+        "password": "your_password"
     }'
 ```
 


### PR DESCRIPTION
https://api.akeneo.com/documentation/security.html#get-a-token

```
To get a valid token, the client application must send the following request:

curl -X POST http://your-host/api/oauth/v1/token \
    -H "Content-Type: application/json" \
    -H "Authorization: Basic YOUR_BASE_64_CLIENT_ID_AND_SECRET" \
    -d '{
        "grant_type": "password",
        "username": your_username,
        "password": your_password
    }'
```
Cause an error 400 invalid json content because it don't have double quote between his username and password.

The example right after is correct (cf https://api.akeneo.com/documentation/security.html#example):
```
[...]
    -d '{
        "grant_type": "password",
        "username": "peter",
        "password": "peter4ever"
    }'
```
