### PR TITLE
Adding http-interop/http-factory-guzzle in the installation part

### DIFF
--- a/content/php-client/getting-started.md
+++ b/content/php-client/getting-started.md
@@ -40,12 +40,12 @@ Run the following command to require the libraries in your project:
 
 ### Community Edition 
 ```bash
-$ php composer.phar require akeneo/api-php-client php-http/guzzle6-adapter
+$ php composer.phar require akeneo/api-php-client php-http/guzzle6-adapter:^2.0 http-interop/http-factory-guzzle:^1.0
 ```
 
 ### Enterprise Edition
 ```bash
-$ php composer.phar require akeneo/api-php-client-ee php-http/guzzle6-adapter
+$ php composer.phar require akeneo/api-php-client-ee php-http/guzzle6-adapter:^2.0 http-interop/http-factory-guzzle:^1.0
 ```
 
 ::: info


### PR DESCRIPTION
The "http-interop/http-factory-guzzle" is needed especially on frameworks like Laravel. If you don't add this you get an error like this:
````
No PSR-17 request factory found. Install a package from this list: https://packagist.org/providers/psr/http-factory-implementation
````