### PR TITLE
Set correctly ui/gid in the container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
+UID = $(shell id -u)
+GID = $(shell id -g)
+
 DOCKER_IMAGE_TAG = pim-api-docs:latest
-DOCKER_RUN = docker run -it --rm -u "$${UID}":"$${GID}" -v "$${PWD}":/opt/workdir -w /opt/workdir
+DOCKER_RUN = docker run -it --rm -u $(UID):$(GID) -v "$${PWD}":/opt/workdir -w /opt/workdir
 
 .PHONY: docker-build yarn-install serve deploy-staging
 .DEFAULT_GOAL := build
@@ -8,7 +11,7 @@ docker-build:
 	docker build -t $(DOCKER_IMAGE_TAG) - < Dockerfile
 
 yarn-install: docker-build
-	$(DOCKER_RUN) $(DOCKER_IMAGE_TAG) yarn install
+	$(DOCKER_RUN) -e HOME=/tmp -v /etc/passwd:/etc/passwd:ro $(DOCKER_IMAGE_TAG) yarn install
 
 watch: yarn-install
 	$(DOCKER_RUN) --expose=8000 -p=8000:8000 $(DOCKER_IMAGE_TAG) yarn gulp serve


### PR DESCRIPTION

> Generally we use docker run -it --rm -u "$${UID}":"$${GID}" to set the UID/GID with docker to use the same id/gid as the host. But if you use Makefile + circle ci, be careful. It uses sh , symlink to dash on Ubuntu. There is no variable such as UID/GID set. So, this trick does not work. If you use bash, it set the UID to 1001 on Circle CI. And commands are failing most of the time as there is no user with id 1001 in the docker container.

By sharing `/etc/passwd`, it works correctly. We have to set `HOME` variable too, otherwise yarn tries to find a file in `/home/circleci/.yarnrc` and this directory does not exist.