### PR TITLE
Rsync needs an existing user to work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ build: yarn-install
 	$(DOCKER_RUN) $(DOCKER_IMAGE_TAG) yarn gulp create-dist
 
 deploy: build
-	$(DOCKER_RUN) -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no" -az --delete dist/ akeneo@$${HOSTNAME}:/var/www/html
+	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no" -az --delete dist/ akeneo@$${HOSTNAME}:/var/www/html


### PR DESCRIPTION
Fix deployment step, because nightly build failed:
https://app.circleci.com/pipelines/github/akeneo/pim-api-docs/414/workflows/eb35a1bc-0fb4-4d83-a923-53444ee25267/jobs/441

It's due to my fix on uid/gid. CI was green as deployment step is not executed.