### PR TITLE
API-1417 Update is_quantified and is_two_way documentation.

### DIFF
--- a/content/php-client/resources/reference-entity/attributes.md
+++ b/content/php-client/resources/reference-entity/attributes.md
@@ -51,8 +51,8 @@ $client->getReferenceEntityAttributeApi()->upsert('brand', 'description', [
         'en_US' => 'Description'
     ],
     'type' => 'text',
-    'localizable' => true,
-    'scopable' => true,
+    'value_per_locale' => true,
+    'value_per_channel' => true,
     'is_required_for_completeness' => false
 ]);
 ```

--- a/content/swagger/resources/association_types/definitions/association_type.yaml
+++ b/content/swagger/resources/association_types/definitions/association_type.yaml
@@ -16,12 +16,12 @@ properties:
         description: Association type label for the locale `localeCode`
   is_quantified:
     type: boolean
-    description: When true, the association is a quantified association
+    description: When true, the association is a quantified association (Only available in the PIM Serenity version.)
     default: false
     x-immutable: true
   is_two_way:
     type: boolean
-    description: When true, the association is a two-way association
+    description: When true, the association is a two-way association (Only available in the PIM Serenity version.)
     default: false
     x-immutable: true
 


### PR DESCRIPTION
Fix 2 documentation issues: https://akeneo.atlassian.net/browse/API-1417 

In the PHP client documentation, replace 

```
'localizable' => true,
        'scopable' => true,
```
by

```
'value_per_locale' => false,
       'value_per_channel' => false,
```

AND

add (Only available in Serenity version) on quantified association parameters. 