### PR TITLE
Fix the example in Rule 3 to match with actual behavior

### DIFF
--- a/content/rest-api/update.md
+++ b/content/rest-api/update.md
@@ -136,7 +136,7 @@ For non-scalar values (objects and arrays) data types must match.
 ```json
 {
   "code": "boots",
-  "parent": "clothes",
+  "parent": "master",
   "labels": {
     "en_US": "Boots",
     "fr_FR": "Bottes"


### PR DESCRIPTION
The original resource in the Rule 3 (VALIDATION ON DATA TYPES) has
"parent": **"master"**

The patch body is empty and therefore, according to the rule, the resulting resource MUST NOT change.

However, the resulting resource in the example has a modified parent
"parent": **"clothes"**

This PR fixes the problem and keeps the initial parent intact.