### PR TITLE
PIM-9992: Duplicate the API doc from products to published products

### DIFF
--- a/content/rest-api/filter.md
+++ b/content/rest-api/filter.md
@@ -761,6 +761,581 @@ Note that you cannot use this filter on several channels.
 When using this query parameter, you will never be able to retrieve products that are not categorized. This is due to the fact that we only return the selection of products that are in the tree linked to the given channel. In other words, if a given product is not categorized in this tree, you won't receive it.
 :::
 
+## Filter on published product properties
+
+To filter products by one of its properties, you can use the `search` query parameter. The value given to this query parameter should be a valid JSON as shown below.
+
+```
+/api/rest/v1/products?search={PRODUCT_PROPERTY:[{"operator":OPERATOR,"value":VALUE}]}
+```
+
+In the above url :
+
+- `PRODUCT_PROPERTY` can be any property detailed in the sections below,
+- `OPERATOR` is an allowed operator for this `PRODUCT_PROPERTY`,
+- `VALUE` is a value whose type corresponds to the allowed type detailed below.
+
+#### Examples
+
+To only retrieve enabled products, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"enabled":[{"operator":"=","value":true}]}
+```
+
+Of course, you can combine as many filters as you want. The example below will get you the enabled products being 70% complete.
+
+```
+/api/rest/v1/products?search={"enabled":[{"operator":"=","value":true}],"completeness":[{"operator":">","value":70,"scope":"ecommerce"}]}
+```
+
+You can even combine several filters on the same product properties. The example below will get you the products created both the 4th and the 5th of July 2016.
+
+```
+/api/rest/v1/products?search={"created":[{"operator":"=","value":"2016-07-04 10:00:00"},{"operator":"=","value":"2016-07-05 10:00:00"}]}
+```
+
+:::info
+Filtering on product properties is also available for published products.
+:::
+
+### On their categories
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+To filter products on their categories, use the property `categories`.
+Here are the allowed operators you can use to filter on the category code as well as the corresponding type of value expected in the `search` query parameter.
+
+| Operator             | Allowed value type                  | Filter description                                                                                      |
+| -------------------- | ----------------------------------- | ------------------------------------------------------------------------------------------------------- |
+| `IN`                 | an array of existing category codes | Only returns the products that are in the given categories                                              |
+| `NOT IN`             | an array of existing category codes | Only returns the products that are not in the given categories                                          |
+| `IN OR UNCLASSIFIED` | an array of existing category codes | Only returns the products that are in the given categories or that are not classified in any categories |
+| `IN CHILDREN`        | an array of existing category codes | Only returns the products that are in the children of the given categories                              |
+| `NOT IN CHILDREN`    | an array of existing category codes | Only returns the products that are not in the children of the given categories                          |
+| `UNCLASSIFIED`       | no value                            | Only returns the products that are not classified into any category                                     |
+
+#### Example
+
+To get the products of the `winter_collection` category, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"categories":[{"operator":"IN","value":["winter_collection"]}]}
+```
+
+:::info
+Filtering on categories is also available for published products.
+:::
+
+### On their status
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+To filter products on their status, use the `enabled` property.
+Here are the allowed operators you can use to filter on the status as well as the corresponding type of value expected in the `search` query parameter.
+
+| Operator | Allowed value type | Filter description                                                    |
+| -------- | ------------------ | --------------------------------------------------------------------- |
+| `=`      | boolean            | Only returns products that are enabled (`true`) or disabled (`false`) |
+| `!=`     | boolean            | Only returns products that are enabled (`false`) or disabled (`true`) |
+
+#### Example
+
+To get the disabled products, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"enabled":[{"operator":"=","value":false}]}
+```
+
+:::info
+Filtering on status is also available for published products.
+:::
+
+### On their completeness
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+To filter products on their completeness, use the `completeness` product property. You will also need to provide a `scope` value to specify on which channel you want to filter with the completeness.
+Here are the allowed operators you can use to filter by completeness as well as the corresponding type of value expected in the `search` query parameter.
+
+| Operator                                                                 | Allowed value type | Filter description                                                                                                                                                 |
+| ------------------------------------------------------------------------ | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `<` or `<=`                                                              | integer            | Only returns products that have a completeness lower than (or equal to) the given value on the given channel independently of locales.                             |
+| `>` or `>=`                                                              | integer            | Only returns products that have a completeness greater than (or equal to) the given value on the given channel independently of locales.                           |
+| `=`                                                                      | integer            | Only returns products that have completeness equal to the given value on the given channel independently of locales.                                               |
+| `!=`                                                                     | integer            | Only returns products that have a completeness different from the given value on the given channel independently of locales.                                       |
+| `GREATER THAN ON ALL LOCALES` or `GREATER OR EQUALS THAN ON ALL LOCALES` | integer            | Only returns products that have a completeness on all locales that is greater than (or equal to) the given value on the given channel for the given set of locales |
+| `LOWER THAN ON ALL LOCALES` or `LOWER OR EQUALS THAN ON ALL LOCALES`     | integer            | Only returns products that have a completeness on all locales that is lower than (or equal to) the given value on the given channel for the given set of locales   |
+
+#### Examples
+
+To get the products that are 100% complete for the `ecommerce` channel, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"completeness":[{"operator":"=","value":100,"scope":"ecommerce"}]}
+```
+
+To get the products that are 100% complete on both the `en_US` and `fr_FR` locales for the `ecommerce` channel, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"completeness":[{"operator":"GREATER OR EQUALS THAN ON ALL LOCALES","value":100,"locales":["en_US","fr_FR"],"scope":"ecommerce"}]}
+```
+
+:::info
+Filtering on completeness is also available for published products.
+:::
+
+### On their group or family
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+To filter products on groups or families, use respectively the product property `groups` and `family`.
+Here are the allowed operators you can use to filter on these properties as well as the corresponding type of value expected in the `search` query parameter.
+
+| Operator    | Allowed value type                | Filter description                                                              |
+| ----------- | --------------------------------- | ------------------------------------------------------------------------------- |
+| `IN`        | array of existing group or family | Only returns products that are respectively in the given families or groups     |
+| `NOT IN`    | array of existing group or family | Only returns products that are respectively not in the given families or groups |
+| `EMPTY`     | no value                          | Only returns products that have respectively no groups or no family             |
+| `NOT EMPTY` | no value                          | Only returns products that have respectively a group or a family                |
+
+#### Examples
+
+To get the products that are in the `promotion` group, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"groups":[{"operator":"IN","value":["promotion"]}]}
+```
+
+To get the products that are not in the `camcorders` and `digital_cameras` family, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"family":[{"operator":"NOT IN","value":["camcorders","digital_cameras"]}]}
+```
+
+:::info
+Filtering on family or group is also available for published products.
+:::
+
+### On their creation or update date
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+To filter products on creation or update date, use respectively the product property `created` and `updated`.
+Here are the allowed operators to filter on these properties as well as the corresponding type of value expected in the `search` query parameter.
+
+:::info
+Note that dates are interpreted in the time zone of the server that runs Akeneo (e.g. date.timezone setting in php.ini).
+:::
+
+| Operator            | Allowed value type                                    | Filter description                                                                                                  |
+| ------------------- | ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------- |
+| `=`                 | datetime <br> _Format: YYYY-MM-DD hh:mm:ss_           | Only returns products that were respectively<br> updated or created during the given day                            |
+| `!=`                | datetime <br> _Format: YYYY-MM-DD hh:mm:ss_           | Only returns products that were respectively<br> not updated or not created during the given day                    |
+| `<`                 | datetime <br> _Format: YYYY-MM-DD hh:mm:ss_           | Only returns products that were respectively<br> updated or created before the given day                            |
+| `>`                 | datetime <br> _Format: YYYY-MM-DD hh:mm:ss_           | Only returns products that were respectively<br> updated or created after the given day                             |
+| `BETWEEN`           | array of datetimes <br> _Format: YYYY-MM-DD hh:mm:ss_ | Only returns products that were respectively<br> updated or created between the two given dates                     |
+| `NOT BETWEEN`       | array of datetimes <br> _Format: YYYY-MM-DD hh:mm:ss_ | Only returns products that were respectively<br> not updated or not created between the two given dates             |
+| `SINCE LAST N DAYS` | integer                                               | Only returns products that were respectively updated<br> or created during the last n days, n being the given value |
+
+|
+
+#### Examples
+
+To get the products that were created on the 4th of July 2016 at 10am, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"created":[{"operator":"=","value":"2016-07-04 10:00:00"}]}
+```
+
+To get the products that were updated during the last 4 days, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"updated":[{"operator":"SINCE LAST N DAYS","value":4}]}
+```
+
+:::info
+Filtering on creation or update date is also available for published products.
+:::
+
+### On their parent
+
+::: availability versions=3.2,4.0,5.0,SaaS editions=CE,EE
+
+To filter products on their parent, use the `parent` product property.
+Here are the allowed operators you can use to filter by parent as well as the corresponding type of value expected in the `search` query parameter.
+
+| Operator    | Allowed value type                 | Filter description                                                                                                                                |
+| ----------- | ---------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `=`         | valid product model code           | Returns products that are descendants of the provided product model. The product model can be either a root product model or a sub product model. |
+| `IN`        | array of valid product model codes | Only returns products that are **direct** children of the provided product models                                                                 |
+| `EMPTY`     | no value                           | Only returns simple products                                                                                                                      |
+| `NOT EMPTY` | no value                           | Only returns variant products                                                                                                                     |
+
+::: warning
+The `IN`, `EMPTY` and `NOT EMPTY` operators are only available for SaaS customers
+:::
+
+#### Examples
+
+To get all the variant products of the `apollon` root product model without having to filter on all its sub-product models, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"parent":[{"operator":"=","value":"apollon"}]}
+```
+
+To get all the variant products of the sub product models with the codes `tshirt_armor_blue` and `tshirt_armor_red`, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"parent":[{"operator":"IN","value":["tshirt_armor_blue","tshirt_armor_red"]}]}
+```
+
+To get all the variant products, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"parent":[{"operator":"NOT EMPTY"}]}
+```
+
+To get all the simple products, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"parent":[{"operator":"EMPTY"}]}
+```
+
+### On their quality score
+
+::: availability versions=SaaS editions=CE,EE
+
+To filter products on their quality score, use the `quality_score` product property. You will also need to provide a `scope` and `locale` value to specify on which channel and locale you want to filter the quality score on.
+This filter accepts one operator: IN. It expects one or several scores, given as a list of letters. The possible values for the quality score are "A", "B", "C", "D" and "E".
+
+#### Examples
+
+To get the products with a "D" for the `ecommerce` channel and `en_US` locale, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"quality_score":[{"operator":"IN","value":["D"],"scope":"ecommerce","locale":"en_US"}]}
+```
+
+To get the products with an "A" or "B" for the `mobile` channel and `en_GB` locale, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"quality_score":[{"operator":"IN","value":["A","B"],"scope":"mobile","locale":"en_GB"}]}
+```
+
+## Filter on published product values
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+To filter products, and product models **since the v2.3**, on its [product values](/concepts/products.html#focus-on-the-products-values), you can use the `search` query parameter when requesting products. The value given to this query parameter should be a valid JSON as shown below.
+
+```
+/api/rest/v1/products?search={ATTIBUTE_CODE:[{"operator":OPERATOR,"value":VALUE,"locale":LOCALE_CODE,"scope":CHANNEL_CODE}]}
+```
+
+In the above url :
+
+- `ATTRIBUTE_CODE` can be any existing attribute code,
+- `OPERATOR` is an allowed operator for the attribute type of the `ATTRIBUTE_CODE` attribute,
+- `VALUE` is a value whose type corresponds to the attribute type of the `ATTRIBUTE_CODE` attribute,
+- `LOCALE_CODE` is an existing locale code that should be only given when the `ATTRIBUTE_CODE` attribute is localizable
+- `CHANNEL_CODE` is an existing channel code that should be only given when the `ATTRIBUTE_CODE` attribute is scopable.
+
+#### Examples
+
+To get products that are purple, purple being an option of the simple select `main_color` attribute and this attribute being neither localizable nor scopable, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"main_color":[{"operator":"IN","value":["purple"]}]}
+```
+
+To get products having a description begining with `Amazing` on the `en_US` locale, the `short_description` attribute being localizable but not scopable, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"short_description":[{"operator":"STARTS WITH","value":"Amazing","locale":"en_US"}]}
+```
+
+To get products that have a release date due after the 4th of July 2016 for the `ecommerce` channel, the `release_date` attribute being scopable but not localizable, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"release_date":[{"operator":">","value":"2016-07-04","scope":"ecommerce"}]}
+```
+
+To get products that have a name that contains with `shirt` on the `en_US` locale for the `mobile` channel, the `name` attribute being both localizable and scopable, you can use the following URL.
+
+```
+/api/rest/v1/products?search={"name":[{"operator":"CONTAINS","value":"shirt","locale":"en_US","scope":"mobile"}]}
+```
+
+Of course, you can combine as many filters as you want. The example below will get you the products with description starting with `Amazing` on the `en_US` locale for the `ecommerce` channel, and of purple color.
+
+```
+/api/rest/v1/products?search={"description":[{"operator":"STARTS WITH","value":"Amazing","locale":"en_US","scope":"ecommerce"}],"main_color":[{"operator":"IN","value":["purple"]}]}
+```
+
+You can even combine several filters on the same attribute. The example below will get you the products with not empty description on the `en_US` locale and empty description on the `fr_FR` locale for the `ecommerce` channel.
+
+```
+/api/rest/v1/products?search={"description":[{"operator":"NOT EMPTY","locale":"en_US","scope":"ecommerce"},{"operator":"EMPTY","locale":"fr_FR","scope":"ecommerce"}]}
+```
+
+:::info
+Filtering on product values is also available for published products.
+:::
+
+### `search_locale` query parameter
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+If you need to filter on several attributes on the same locale, you can use the `search_locale` query parameter, to avoid repeating yourself for each attribute. This parameter expect an existing locale code.
+
+#### Example
+
+```
+/api/rest/v1/products?search={"description":[{"operator":"STARTS WITH","value":"Amazing","locale":"en_US","scope":"ecommerce"}],"short_description":[{"operator":"CONTAINS","value":"shoes","locale":"en_US","scope":"ecommerce"}]}
+
+is equivalent to
+
+/api/rest/v1/products?search={"description":[{"operator":"STARTS WITH","value":"Amazing","scope":"ecommerce"}],"short_description":[{"operator":"CONTAINS","value":"shoes","scope":"ecommerce"}]}&search_locale=en_US
+```
+
+:::info
+This query parameter is also available for the published products.
+:::
+
+### `search_scope` query parameter
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+If you need to filter on several attributes on the same channel, you can use the `search_scope` query parameter, to avoid repeating yourself for each attribute. This parameter expect an existing channel code.
+
+#### Example
+
+```
+/api/rest/v1/products?search={"release_date":[{"operator":">","value":"2016-07-04","scope":"ecommerce"}],"short_description":[{"operator":"CONTAINS","value":"shoes","locale":"en_US","scope":"ecommerce"}]}
+
+is equivalent to
+
+/api/rest/v1/products?search={"release_date":[{"operator":">","value":"2016-07-04"}],"short_description":[{"operator":"CONTAINS","value":"shoes","locale":"en_US"}]}&search_scope=ecommerce
+```
+
+:::info
+This query parameter is also available for the published products.
+:::
+
+### Available operators
+
+As seen previously, the attribute type determines which set of operators is available to use these filters.
+
+**The `pim_catalog_identifier`, `pim_catalog_text` and `pim_catalog_textarea` attribute types**
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+| Allowed operators                                  | Allowed value type |
+| -------------------------------------------------- | ------------------ |
+| STARTS WITH, ENDS WITH, CONTAINS, DOES NOT CONTAIN | string             |
+| =, !=                                              | string             |
+| EMPTY, NOT EMPTY                                   | no value           |
+
+**The `pim_catalog_number`, `pim_catalog_metric` and `pim_catalog_price_collection` attribute types**
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+| Allowed operators   | Allowed value type |
+| ------------------- | ------------------ |
+| <, <=, =, !=, >=, > | integer            |
+| EMPTY, NOT EMPTY    | no value           |
+
+**The `pim_catalog_simpleselect` and `pim_catalog_multiselect` attribute types**
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+| Allowed operators | Allowed value type                                 |
+| ----------------- | -------------------------------------------------- |
+| IN, NOT IN        | an existing attribute option code of the attribute |
+| EMPTY, NOT EMPTY  | no value                                           |
+
+**The `pim_catalog_boolean` attribute type**
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+| Allowed operators | Allowed value type                                 |
+| ----------------- | -------------------------------------------------- |
+| =, !=             | boolean                                            |
+| EMPTY, NOT EMPTY  | no value (only available on 5.0 and SaaS versions) |
+
+**The `pim_catalog_date` attribute type**
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+| Allowed operators    | Allowed value type                         |
+| -------------------- | ------------------------------------------ |
+| <, =, !=, >          | dateTime (ISO-8601)                        |
+| BETWEEN, NOT BETWEEN | [dateTime (ISO-8601), dateTime (ISO-8601)] |
+| EMPTY, NOT EMPTY     | no value                                   |
+
+**The `pim_catalog_file` and `pim_catalog_image` attribute types**
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+| Allowed operators                                         | Allowed value type |
+| --------------------------------------------------------- | ------------------ |
+| STARTS WITH, ENDS WITH, CONTAINS, DOES NOT CONTAIN, =, != | string             |
+| EMPTY, NOT EMPTY                                          | no value           |
+
+## Filter published product values
+
+Thanks to the above sections, you are able to filter your products to only get those you want. In this section, you will see that you also can filter the product values to only receive those you want.
+
+:::info
+Filtering product values via attributes, channel or locale is also available for published products.
+:::
+
+### Via attributes
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+If you want to receive for each product only product values about specific attributes, you can specify it thanks to the `attributes` query parameter.
+
+#### Example
+
+To get products with only product values regarding the `description` attribute, you can use the following URL.
+
+```
+/api/rest/v1/products?attributes=description
+```
+
+You can filter product values on several attributes at the same time.
+
+```
+/api/rest/v1/products?attributes=name,description
+```
+
+### Via locale
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+If you want to receive for each product only product values on specific locales, as well as the product values of the non localizable attributes, you can specify it thanks to the `locales` query parameter.
+
+#### Example 1
+
+Imagine that without this filter you get these product values:
+
+```json
+{
+  "color": [
+    {
+      "data": "carmine_red",
+      "locale": null,
+      "scope": null
+    }
+  ],
+  "name": [
+    {
+      "data": "Top",
+      "locale": "en_US",
+      "scope": null
+    },
+    {
+      "data": "Débardeur",
+      "locale": "fr_FR",
+      "scope": null
+    }
+  ],
+  "description": [
+    {
+      "data": "Summer top",
+      "locale": "en_US",
+      "scope": "ecommerce"
+    },
+    {
+      "data": "Top",
+      "locale": "en_US",
+      "scope": "tablet"
+    },
+    {
+      "data": "Débardeur pour l'été",
+      "locale": "fr_FR",
+      "scope": "ecommerce"
+    },
+    {
+      "data": "Débardeur",
+      "locale": "fr_FR",
+      "scope": "tablet"
+    }
+  ]
+}
+```
+
+To get only product values regarding the `en_US` locale (+ the product values of the non localizable attributes), you can use the following URL.
+
+```
+/api/rest/v1/products?locales=en_US
+```
+
+As a result you will receive the following answer:
+
+```json
+{
+  "color": [
+    {
+      "data": "carmine_red",
+      "locale": null,
+      "scope": null
+    }
+  ],
+  "name": [
+    {
+      "data": "Top",
+      "locale": "en_US",
+      "scope": null
+    }
+  ],
+  "description": [
+    {
+      "data": "Summer top",
+      "locale": "en_US",
+      "scope": "ecommerce"
+    },
+    {
+      "data": "Top",
+      "locale": "en_US",
+      "scope": "tablet"
+    }
+  ]
+}
+```
+
+::: warning
+As you can see, for the simple select attribute named `color`, as the attribute is not localizable (the `locale` field is set to `null`), the product value of this attribute is not filtered and you still get the code of the attribute option, `carmine_red`.
+If you want to get the localized label of this attribute option, you will have to request the [attribute option endpoint](/api-reference.html#get_attributes__attribute_code__options__code_).
+:::
+
+#### Example 2
+
+You can also filter product values on several locales at the same time.
+
+```
+/api/rest/v1/products?locales=en_US,fr_FR
+```
+
+### Via channel
+
+::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE
+
+There is also a `scope` query parameter that will allow you to:
+
+- get only the selection of products that are in the tree linked to the channel you specified,
+- get only the product values for this specific channel, as well as the product values of the non scopable attributes.
+
+#### Example
+
+To get products from the tree linked to the `ecommerce` channel with only product values regarding the `ecommerce` channel (+ the product values of the non scopable attributes), you can use the following URL.
+
+```
+/api/rest/v1/products?scope=ecommerce
+```
+
+:::warning
+Note that you cannot use this filter on several channels.
+:::
+
+:::info
+When using this query parameter, you will never be able to retrieve products that are not categorized. This is due to the fact that we only return the selection of products that are in the tree linked to the given channel. In other words, if a given product is not categorized in this tree, you won't receive it.
+:::
+
 ## Filter locales
 
 ::: availability versions=1.7,2.x,3.x,4.0,5.0,SaaS editions=CE,EE

--- a/content/swagger/resources/published_products/routes/published_products.yaml
+++ b/content/swagger/resources/published_products/routes/published_products.yaml
@@ -20,12 +20,12 @@ get:
     - name: scope
       in: query
       type: string
-      description: Filter published product values to return scopable attributes for the given channel as well as the non localizable/non scopable attributes, for more details see the <a href="/documentation/filter.html#filter-product-values">Filter on published product values</a> section
+      description: Filter published product values to return scopable attributes for the given channel as well as the non localizable/non scopable attributes, for more details see the <a href="/documentation/filter.html#filter-published-product-values">Filter on published product values</a> section
       required: false
     - name: locales
       in: query
       type: string
-      description: Filter published product values to return localizable attributes for the given locales as well as the non localizable/non scopable attributes, for more details see the <a href="/documentation/filter.html#filter-product-values">Filter on published product values</a> section
+      description: Filter published product values to return localizable attributes for the given locales as well as the non localizable/non scopable attributes, for more details see the <a href="/documentation/filter.html#filter-published-product-values">Filter on published product values</a> section
       required: false
     - name: attributes
       in: query


### PR DESCRIPTION
I duplicated the the API doc from products to published products **except for** the "filter on product models" part because, unless I am mistaken, the "published product models" do not exist.
The content of this new section will be modified in the next PRs.