### PR TITLE
fix illus--System.svg 404 not found

### DIFF
--- a/content/img/illustrations/illus--System.svg
+++ b/content/img/illustrations/illus--System.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>


### PR DESCRIPTION
Fix that issue: 
<img width="842" alt="Capture d’écran 2021-09-13 à 14 47 40" src="https://user-images.githubusercontent.com/63229723/133089153-feb85886-1351-4461-ac60-dc7d593b02a5.png">
