### PR TITLE
CXP-1168: Added Apps warning in events api basics and moved introduction

### DIFF
--- a/content/events-api/introduction.md
+++ b/content/events-api/introduction.md
@@ -1,7 +1,0 @@
-# 👋 Welcome in the Events API basics documentation!
-
-You are probably asking yourself a ton of questions about our Events API, that's why we made this article.
-
-::: warning
-The Events API feature is only available in the **5.0 version** and higher and for **SaaS** customers.
-:::

--- a/content/events-api/overview.md
+++ b/content/events-api/overview.md
@@ -1,4 +1,11 @@
-# Overview
+# 👋 Welcome in the Events API basics documentation!
+
+You are probably asking yourself a ton of questions about our Events API, that's why we made this article.
+
+::: warning
+The Events API feature is only available in the **5.0 version** and higher and for **SaaS** customers.
+:::
+
 
 _All the essential things you need to know._
 
@@ -6,6 +13,10 @@ Using the Akeneo Events API, you will receive events on product creation, produc
 The feature is working as well on simple products as on product models and variants.
 
 Simple products and product variants have similar event formats, but events related to product models are a bit different. That is why we detailed each event type format in our [Events API Reference](../events-reference/events-reference-serenity/products.html)
+
+::: warning
+The events API feature is not currently available for **Apps**.
+:::
 
 ::: info 
 For more information, please read our help center article [What is an event subscription?](https://help.akeneo.com/pim/serenity/articles/what-is-an-event-subscription.html) to discover which type of events Akeneo PIM triggers and in what cases. 

--- a/tasks/build-doc.js
+++ b/tasks/build-doc.js
@@ -521,7 +521,6 @@ gulp.task('build-rest-api', ['clean-dist','less'], function () {
 gulp.task('build-events-api', ['clean-dist','less'], function () {
 
     var pages = {
-        'introduction.md': 'Introduction',
         'overview.md': 'Overview',
         'subscription.md': 'Subscribe and receive events',
         'security.md': 'Security',


### PR DESCRIPTION
Added warning regarding the use of events API with the Apps

I've also moved the events API basics introduction (almost an empty page) into the overview page

![image](https://user-images.githubusercontent.com/7101819/165765361-cae16a3e-0e3b-417a-a713-284598714fab.png)
