### PR TITLE
Add CODEOWNERS on Apps documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+content/apps/ @akeneo/squad-octopus


### PR DESCRIPTION
According to the latest ownership distribution of the features, https://www.notion.so/akeneo/Apps-66d9ceddf4324341a156cdda79c1f1a3, all pages regarding the App Documentation are owned and maintained by the octopus.

The `CODEOWNERS` configuration will ensure that any PR on the App documentation must be approved by at least one Octopus to be merged.