### PR TITLE
Works around RSA disabling on recent SSH version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ build: yarn-install
 	$(DOCKER_RUN) $(DOCKER_IMAGE_TAG) yarn gulp create-dist
 
 deploy: build
-	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no" -az --delete dist/ akeneo@$${HOSTNAME}:/var/www/html
+	$(DOCKER_RUN) -v /etc/passwd:/etc/passwd:ro -v $${SSH_AUTH_SOCK}:/ssh-auth.sock:ro -e SSH_AUTH_SOCK=/ssh-auth.sock $(DOCKER_IMAGE_TAG) rsync --no-v -e "ssh -q -p $${PORT} -o StrictHostKeyChecking=no -o PubkeyAcceptedKeyTypes=+ssh-rsa" -az --delete dist/ akeneo@$${HOSTNAME}:/var/www/html


### PR DESCRIPTION
The last Alpine Linux being used for the Docker image, it provides a recent version of SSH, where RSA support is disabled.