### PR TITLE
Remove string from boolean attribute update

### DIFF
--- a/content/concepts/products.md
+++ b/content/concepts/products.md
@@ -471,7 +471,7 @@ Whenever the attribute's type is `pim_catalog_boolean`, the `data` field should 
       {
         "locale": null,
         "scope": null,
-        "data": "true"
+        "data": true
       }
     ]
   }


### PR DESCRIPTION
https://api.akeneo.com/concepts/products.html#boolean-attribute

Data field should contain either true or false, but a string is given in the example.