### PR TITLE
docs: fix typos

### DIFF
--- a/content/concepts/asset-manager.md
+++ b/content/concepts/asset-manager.md
@@ -3,7 +3,7 @@ The Asset Manager is a brand new and more efficient way to manage the assets lin
 
 The assets of the Asset Manager will be way more powerful than before. They will benefit from 4 major new features:
 - the possibility to define a flexible structure, thanks to the [asset families](#the-asset-family),
-- the possibility to automatize the link with your products, thanks to the [product link rules](#focus-on-the-product-link-rule) and the [naming convention](#focus-on-the-naming-convention),
+- the possibility to automate the link with your products, thanks to the [product link rules](#focus-on-the-product-link-rule) and the [naming convention](#focus-on-the-naming-convention),
 - the possibility to refer to both external and internal binaries, thanks to the [media link](#the-media-link-attribute) and the [media file](#the-media-file-attribute) attribute types,
 - the posibility to have flexible asset [transformations](#focus-on-the-transformations).
 
@@ -328,7 +328,7 @@ The JSON format of the product link rules is an array of product link rules. A p
 ```
 
 ::: warning
-A piece of advice: when defining two different rules on an asset family, make sure you define different product selections in each rule, as shown in the example above. Why? Because you could experience performance issues. If you want to assign your assets to two different product attributes on a given selection of products, use one single rule, with two assigments in the `assign_assets_to` field. See the [Product value assigment](#product-value-assignment) section for an example.
+A piece of advice: when defining two different rules on an asset family, make sure you define different product selections in each rule, as shown in the example above. Why? Because you could experience performance issues. If you want to assign your assets to two different product attributes on a given selection of products, use one single rule, with two assignments in the `assign_assets_to` field. See the [Product value assignment](#product-value-assignment) section for an example.
 :::
 
 Looks barbaric? Don't freak out! The following sections are here to help you understand this rule and how you can make the most of it. You'll see, it's super powerful! :)
@@ -1174,7 +1174,7 @@ If the `MEDIA_FILE_ATTRIBUTE_NAME` is the code of an attribute that is not scopa
 :::
 
 ::: info
-There are additionnal business rules regarding this `target` property whenever you have multiple transformations for the same asset family. See the [Dealing with several transformations](#dealing-with-several-transformations) section for more details.
+There are additional business rules regarding this `target` property whenever you have multiple transformations for the same asset family. See the [Dealing with several transformations](#dealing-with-several-transformations) section for more details.
 :::
 
 ### Target filename
@@ -1229,7 +1229,7 @@ The `operations` property follows this format:
 ```
 
 In this formula:
- - `OPERATION_NAME` is the name of the operation that should be perfomed on the source file. The complete list of available operations is detailed below.
+ - `OPERATION_NAME` is the name of the operation that should be performed on the source file. The complete list of available operations is detailed below.
  - `OPERATION_PARAMETERS` is the set of parameters for the operation. It depends on the `OPERATION_NAME` chosen before.
 
 ::: warning

--- a/content/concepts/reference-entities.md
+++ b/content/concepts/reference-entities.md
@@ -457,7 +457,7 @@ Note that the `locale` and `channel` properties are all set to `null` in this ca
 ::: availability versions=3.x,4.0,5.0,6.0,7.0,SaaS editions=EE
 :::
 
-Reference entity media files corresponds to the images that you can link to the records of your reference entities and also, to the images that you can direclty link to your reference entities.
+Reference entity media files corresponds to the images that you can link to the records of your reference entities and also, to the images that you can directly link to your reference entities.
 
 In the Akeneo UI, you can find these media files in the detail of a record. In the screenshot below, there are two record media files: 
 - the first image with the logo of the brand,

--- a/content/getting-started/connect-the-pim-4x/step-2.md
+++ b/content/getting-started/connect-the-pim-4x/step-2.md
@@ -96,7 +96,7 @@ Don't try to do everything at once, there are high chances you won't see the end
 
 ### UI or not UI?
 
-Some connectors also require the developement of a UI. For example, it can be very useful in the case you want your final users to be able to input some configuration. Indeed, in some cases, you may want to ask them for product, channel or locale selections.
+Some connectors also require the development of a UI. For example, it can be very useful in the case you want your final users to be able to input some configuration. Indeed, in some cases, you may want to ask them for product, channel or locale selections.
 
 Another option is to provide a configuration file to input this configuration. It's usually faster to develop but keep in mind that you will be far from delivering the best UX for your final users. :wink:
 

--- a/content/getting-started/connect-the-pim-old/step-1.md
+++ b/content/getting-started/connect-the-pim-old/step-1.md
@@ -92,7 +92,7 @@ Don't try to do everything at once, they are high chances you won't see the end 
 
 ### UI or not UI?
 
-Some connectors also require the developement of a UI. For example, it can be very useful in the case you want your final users to be able to input some configuration. Indeed, in some cases, you may want to ask them for product, channel or locale selections.
+Some connectors also require the development of a UI. For example, it can be very useful in the case you want your final users to be able to input some configuration. Indeed, in some cases, you may want to ask them for product, channel or locale selections.
 
 Another option is to provide a configuration file to input this configuration. It's usually faster to develop but keep in mind that you will be far from delivering the best UX for your final users. :wink:
 

--- a/content/getting-started/from-identifiers-to-uuid-7x/welcome.md
+++ b/content/getting-started/from-identifiers-to-uuid-7x/welcome.md
@@ -35,7 +35,7 @@ But before making it happen, a product must have a **unique** and **immutable** 
 
 ## What are the impacts?
 
-Of course, [Products endpoints](https://api.akeneo.com/api-reference.html#Product) will remain available (and they be enriched with a `UUID` property), even whith the availability of the new API endpoints.
+Of course, [Products endpoints](https://api.akeneo.com/api-reference.html#Product) will remain available (and they be enriched with a `UUID` property), even with the availability of the new API endpoints.
 Nevertheless, now that the current product identifier is optional:
 - [GET /api/rest/v1/products](https://api.akeneo.com/api-reference.html#get_products) won’t return products with empty product identifiers (in other words, you may miss products if you continue to use this endpoint);
 - `associations` property for [GET /api/rest/v1/products](https://api.akeneo.com/api-reference.html#get_products) or [GET /api/rest/v1/products/{code}](https://api.akeneo.com/api-reference.html#get_products__code_) may contain **NULL** values (product associated with a product without identifier);

--- a/content/rest-api/filter.md
+++ b/content/rest-api/filter.md
@@ -468,7 +468,7 @@ To get products that are purple, purple being an option of the simple select `ma
 /api/rest/v1/products-uuid?search={"main_color":[{"operator":"IN","value":["purple"]}]}
 ```
 
-To get products having a description begining with `Amazing` on the `en_US` locale, the `short_description` attribute being localizable but not scopable, you can use the following URL.
+To get products having a description beginning with `Amazing` on the `en_US` locale, the `short_description` attribute being localizable but not scopable, you can use the following URL.
 
 ```
 /api/rest/v1/products-uuid?search={"short_description":[{"operator":"STARTS WITH","value":"Amazing","locale":"en_US"}]}
@@ -973,7 +973,7 @@ To get published products that are purple, purple being an option of the simple 
 /api/rest/v1/published-products?search={"main_color":[{"operator":"IN","value":["purple"]}]}
 ```
 
-To get published products having a description begining with `Amazing` on the `en_US` locale, the `short_description` attribute being localizable but not scopable, you can use the following URL.
+To get published products having a description beginning with `Amazing` on the `en_US` locale, the `short_description` attribute being localizable but not scopable, you can use the following URL.
 
 ```
 /api/rest/v1/published-products?search={"short_description":[{"operator":"STARTS WITH","value":"Amazing","locale":"en_US"}]}

--- a/content/rest-api/pagination.md
+++ b/content/rest-api/pagination.md
@@ -167,7 +167,7 @@ curl -X GET /api/rest/v1/products-uuid
 
 When trying to request a quite high page number, you will notice that this method spend more and more time to respond. This method can also be responsible for giving you duplicates. That is why we introduced another way to request paginated resources, see the [`Search-after` method](/documentation/pagination.html#the-search-after-method). It is only avalailable on products, product models, published products, assets, reference entities and reference entity records right now.
 
-For somes high volume entities, an offset limit exist, after that an error with code 422 will be sent back.
+For some high volume entities, an offset limit exist, after that an error with code 422 will be sent back.
 ``` bash
 
 // Max offset for product trying to fetch after the 10.000th product

--- a/content/rest-api/why-the-api.md
+++ b/content/rest-api/why-the-api.md
@@ -30,7 +30,7 @@ Also, if you're dealing with REST API breaks that weren't announced and not docu
 
 Starting the v3 version of the PIM, we worked a lot on improving the performance of our PIM, including our REST API.
 
-As an example, starting from the v4, the REST API is 3 times faster than the traditionnal exports of flat files.
+As an example, starting from the v4, the REST API is 3 times faster than the traditional exports of flat files.
 Also regarding, the imports of products, if you want to gain speed, with the REST API you can easily parallelize your requests.
 
 Today, the REST API is officially the **most performant way** to connect the PIM.

--- a/content/swagger/parameters.yaml
+++ b/content/swagger/parameters.yaml
@@ -93,7 +93,7 @@ family_code:
 with_count:
   name: with_count
   in: query
-  description: Return the count of items in the response. Be carefull with that, on a big catalog, it can decrease performance in a significative way
+  description: Return the count of items in the response. Be careful with that, on a big catalog, it can decrease performance in a significative way
   default: false
   type: boolean
   required: false

--- a/content/swagger/resources/attributes/definitions/attribute.yaml
+++ b/content/swagger/resources/attributes/definitions/attribute.yaml
@@ -51,7 +51,7 @@ properties:
       x-immutable: true
   available_locales:
     type: array
-    description: To make the attribute locale specfic, specify here for which locales it is specific
+    description: To make the attribute locale specific, specify here for which locales it is specific
     x-validation-rules: Each string of the array is an existing and activated locale
     items:
       type: string


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

4 typos in `content/concepts/asset-manager.md`
1 typo in `content/concepts/reference-entities.md`
1 typo in `content/getting-started/connect-the-pim-4x/step-2.md`
1 typo in `content/getting-started/connect-the-pim-old/step-1.md`
1 typo in `content/getting-started/from-identifiers-to-uuid-7x/welcome.md`
2 typos in `content/rest-api/filter.md`
1 typo in `content/rest-api/pagination.md`
1 typo in `content/rest-api/why-the-api.md`
1 typo in `content/swagger/parameters.yaml`
1 typo in `content/swagger/resources/attributes/definitions/attribute.yaml`


Best!