### PR TITLE
CXP-1639: add mapping meta-schema v0.3.0

### DIFF
--- a/content/mapping/product/0.3.0/schema
+++ b/content/mapping/product/0.3.0/schema
@@ -1,0 +1,685 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://api.akeneo.com/mapping/product/0.3.0/schema",
+    "type": "object",
+    "properties": {
+        "$id": { "$ref": "#/$defs/$id" },
+        "$schema": { "$ref": "#/$defs/$schema" },
+        "$comment": { "$ref": "#/$defs/$comment" },
+        "$defs": { "$ref": "#/$defs/$defs" },
+        "title": { "$ref": "#/$defs/title" },
+        "description": { "$ref": "#/$defs/description" },
+        "type": {
+            "const": "object"
+        },
+        "properties": {
+            "type": "object",
+            "oneOf": [
+                { "$ref": "#/$defs/flatProductsMode" },
+                { "$ref": "#/$defs/productsWithVariantsMode" }
+            ],
+            "default": {}
+        },
+        "required": { "$ref": "#/$defs/requiredConstraint" }
+    },
+    "$defs": {
+        "$id": {
+            "$comment": "Non-empty fragments not allowed.",
+            "pattern": "^[^#]*#?$"
+        },
+        "$schema": { "$ref": "#/$defs/uriString" },
+        "$comment": {
+            "type": "string"
+        },
+        "$defs": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#/$defs/property" }
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "property": {
+            "type": "object",
+            "properties": {
+                "title": { "$ref": "#/$defs/title" },
+                "description": { "$ref": "#/$defs/description" },
+                "type": {
+                    "enum": ["string", "number", "boolean", "array", "object"]
+                },
+                "format": { "$ref": "#/$defs/format" },
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "enum": ["string", "object"]
+                        },
+                        "format": {
+                            "enum": ["uri"]
+                        },
+                        "enum": { "$ref": "#/$defs/enum" },
+                        "properties": {
+                            "type": "object",
+                            "properties": {
+                                "amount": { "$ref": "#/$defs/amountProperty" },
+                                "currency": { "$ref": "#/$defs/currencyProperty" },
+                                "locale": { "$ref": "#/$defs/localizableProperty" },
+                                "value": { "$ref": "#/$defs/localizableValueProperty" }
+                            },
+                            "dependencies": {
+                                "amount": {
+                                    "not": {
+                                        "anyOf": [
+                                            { "required": ["locale"] },
+                                            { "required": ["value"] }
+                                        ]
+                                    }
+                                },
+                                "locale": {
+                                    "not": {
+                                        "anyOf": [
+                                            { "required": ["amount"] },
+                                            { "required": ["currency"] }
+                                        ]
+                                    }
+                                }
+                            },
+                            "dependentRequired": {
+                                "amount": ["currency"],
+                                "currency": ["amount"],
+                                "locale": ["value"],
+                                "value": ["locale"]
+                            }
+                        },
+                        "required": {
+                            "type": "array"
+                        }
+                    },
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "object"
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": ["properties", "required"]
+                    },
+                    "dependentSchemas": {
+                        "format": {
+                            "properties": {
+                                "type": {
+                                    "enum": ["string"]
+                                }
+                            },
+                            "required": ["type"]
+                        },
+                        "enum": {
+                            "if": {
+                                "properties": {
+                                    "type": {
+                                        "const": "string"
+                                    }
+                                }
+                            },
+                            "then": {
+                                "properties": {
+                                    "enum": {
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            },
+                            "required": ["type"]
+                        },
+                        "properties": {
+                            "allOf": [
+                                {
+                                    "if": {
+                                        "properties": {
+                                            "properties": { "$ref": "#/$defs/priceFullProperty" }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "required": { "$ref": "#/$defs/priceRequiredProperty" }
+                                        }
+                                    }
+                                },
+                                {
+                                    "if": {
+                                        "properties": {
+                                            "properties": { "$ref": "#/$defs/localizedFullProperty" }
+                                        }
+                                    },
+                                    "then": {
+                                        "properties": {
+                                            "required": { "$ref": "#/$defs/localizableRequiredProperty" }
+                                        }
+                                    }
+                                }
+                            ]
+                        },
+                        "required": {
+                            "properties": {
+                                "type": {
+                                    "const": "object"
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "minLength": { "$ref": "#/$defs/minLength" },
+                "maxLength": { "$ref": "#/$defs/maxLength" },
+                "pattern": { "$ref": "#/$defs/pattern" },
+                "minimum": { "$ref": "#/$defs/minimum" },
+                "maximum": { "$ref": "#/$defs/maximum" },
+                "enum": { "$ref": "#/$defs/enum" },
+                "properties": {
+                    "type": "object",
+                    "properties": {
+                        "amount": { "$ref": "#/$defs/amountProperty" },
+                        "currency": { "$ref": "#/$defs/currencyProperty" },
+                        "locale": { "$ref": "#/$defs/localizableProperty" },
+                        "value": { "$ref": "#/$defs/localizableValueProperty" }
+                    },
+                    "dependencies": {
+                        "amount": {
+                            "properties" : {
+                                "locale": false,
+                                "value": false
+                            }
+                        },
+                        "locale": {
+                            "properties": {
+                                "amount": false,
+                                "currency": false
+                            }
+                        }
+                    },
+                    "dependentRequired": {
+                        "amount": ["currency"],
+                        "currency": ["amount"],
+                        "locale": ["value"],
+                        "value": ["locale"]
+                    }
+                },
+                "required": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "additionalProperties": false,
+            "allOf": [
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "array"
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": ["items"]
+                    }
+                },
+                {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "object"
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": ["properties"],
+                        "oneOf": [
+                            {
+                                "properties": {
+                                    "required": { "$ref": "#/$defs/priceRequiredProperty" }
+                                }
+                            },
+                            {
+                                "properties": {
+                                    "required": { "$ref": "#/$defs/localizableRequiredProperty" }
+                                }
+                            }
+                        ]
+                    }
+                }
+            ],
+            "required": ["type"],
+            "dependentSchemas": {
+                "format": {
+                    "properties": {
+                        "type": {
+                            "enum": ["string"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "items": {
+                    "properties": {
+                        "type": {
+                            "enum": ["array"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "minLength": {
+                    "properties": {
+                        "type": {
+                            "enum": ["string"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "maxLength": {
+                    "properties": {
+                        "type": {
+                            "enum": ["string"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "pattern": {
+                    "properties": {
+                        "type": {
+                            "enum": ["string"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "minimum": {
+                    "properties": {
+                        "type": {
+                            "enum": ["number"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "maximum": {
+                    "properties": {
+                        "type": {
+                            "enum": ["number"]
+                        }
+                    },
+                    "required": ["type"]
+                },
+                "enum": {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "string"
+                            }
+                        }
+                    },
+                    "then": {
+                        "properties": {
+                            "enum": {
+                                "items": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    },
+                    "else": {
+                        "if": {
+                            "properties": {
+                                "type": {
+                                    "const": "number"
+                                }
+                            }
+                        },
+                        "then": {
+                            "properties": {
+                                "enum": {
+                                    "items": {
+                                        "type": "number"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "required": [
+                        "type"
+                    ]
+                },
+                "type": {
+                    "if": {
+                        "properties": {
+                            "type": {
+                                "const": "object"
+                            }
+                        }
+                    },
+                    "then": {
+                        "required": ["properties", "required"]
+                    }
+                },
+                "properties": {
+                    "properties": {
+                        "type": {
+                            "const": "object"
+                        }
+                    }
+                }
+            }
+        },
+        "amountProperty": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "number"
+                }
+            },
+            "required": ["type"]
+        },
+        "currencyProperty": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "string"
+                },
+                "enum": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "required": ["type"]
+        },
+        "priceFullProperty": {
+            "type": "object",
+            "properties": {
+                "amount": { "$ref": "#/$defs/amountProperty" },
+                "currency": { "$ref": "#/$defs/currencyProperty" }
+            },
+            "required": ["amount", "currency"],
+            "additionalProperties": false
+        },
+        "priceRequiredProperty": {
+            "type": "array",
+            "items": {
+                "enum": ["amount", "currency"]
+            },
+            "minItems": 2,
+            "maxItems": 2,
+            "uniqueItems": true
+        },
+        "localizableProperty": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "string"
+                }
+            },
+            "required": ["type"],
+            "additionalProperties": false
+        },
+        "localizableValueProperty": {
+            "type": "object",
+            "if": {
+                "properties": {
+                    "type": {
+                        "const": "array"
+                    }
+                }
+            },
+            "then": {
+                "required": ["items"]
+            },
+            "properties": {
+                "type": {
+                    "enum": ["string", "array", "boolean", "number", "object"]
+                },
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "enum": ["string", "object"]
+                        },
+                        "enum": { "$ref": "#/$defs/enum" },
+                        "format": { "$ref": "#/$defs/format" },
+                        "properties": { "$ref": "#/$defs/priceFullProperty" },
+                        "required": {
+                            "type": "array",
+                            "items": {
+                                "enum": ["amount", "currency"]
+                            },
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "uniqueItems": true
+                        }
+                    },
+                    "dependentSchemas": {
+                        "properties": {
+                            "required": ["required"]
+                        }
+                    },
+                    "additionalProperties": false
+                },
+                "format": { "$ref": "#/$defs/format" },
+                "minLength": { "$ref": "#/$defs/minLength" },
+                "maxLength": { "$ref": "#/$defs/maxLength" },
+                "pattern": { "$ref": "#/$defs/pattern" },
+                "minimum": { "$ref": "#/$defs/minimum" },
+                "maximum": { "$ref": "#/$defs/maximum" },
+                "properties": {
+                    "type": "object",
+                    "$ref": "#/$defs/priceFullProperty"
+                }
+            },
+            "required": ["type"]
+        },
+        "localizedFullProperty": {
+            "type": "object",
+            "properties": {
+                "locale": { "$ref": "#/$defs/localizableProperty" },
+                "value": { "$ref": "#/$defs/localizableValueProperty" }
+            },
+            "required": ["locale", "value"],
+            "additionalProperties": false
+        },
+        "localizableRequiredProperty": {
+            "type": "array",
+            "items": {
+                "enum": ["locale", "value"]
+            },
+            "minItems": 2,
+            "maxItems": 2,
+            "uniqueItems": true
+        },
+        "uriString": {
+            "type": "string",
+            "format": "uri"
+        },
+        "flatProductsMode": {
+            "properties": {
+                "uuid": { "$ref": "#/$defs/uuidProperty" },
+                "id": false,
+                "attribute_axes": false,
+                "variants": false
+            },
+            "additionalProperties": { "$ref": "#/$defs/property" },
+            "required": ["uuid"]
+        },
+        "productsWithVariantsMode": {
+            "properties": {
+                "uuid": false,
+                "id": { "$ref": "#/$defs/idProperty" },
+                "attribute_axes": { "$ref": "#/$defs/attributeAxesProperty" },
+                "variants": { "$ref": "#/$defs/variantsConstraint" }
+            },
+            "additionalProperties": { "$ref": "#/$defs/property" },
+            "required": ["id", "attribute_axes", "variants"]
+        },
+        "uuidProperty": {
+            "type": "object",
+            "properties": {
+                "title": {"$ref": "#/$defs/title" },
+                "description": {"$ref": "#/$defs/description" },
+                "type": {
+                    "const": "string"
+                }
+            },
+            "additionalProperties": false,
+            "required": [
+                "type"
+            ]
+        },
+        "idProperty": {
+            "type": "object",
+            "properties": {
+                "title": { "$ref": "#/$defs/title" },
+                "description": { "$ref": "#/$defs/description" },
+                "type": {
+                    "const": ["string", "null"]
+                }
+            },
+            "additionalProperties": false,
+            "required": ["type"]
+        },
+        "attributeAxesProperty": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "object"
+                },
+                "properties": {
+                    "type": "object",
+                    "patternProperties": {
+                        "^(axis_([1-9]|10))+$": {
+                            "type": "object",
+                            "properties": {
+                                "type": {
+                                    "const": "string"
+                                }
+                            }
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false,
+            "required": ["type", "properties"]
+        },
+        "variantsConstraint": {
+            "type": "object",
+            "properties": {
+                "oneOf": {
+                    "type": "array",
+                    "prefixItems": [
+                        { "$ref": "#/$defs/variantsAsURI" },
+                        { "$ref": "#/$defs/variantsAsList" }
+                    ],
+                    "minItems": 2,
+                    "maxItems": 2
+                }
+            },
+            "additionalProperties": false,
+            "required": ["oneOf"]
+        },
+        "variantsAsURI": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "string"
+                },
+                "format": {
+                    "const": "uri"
+                }
+            },
+            "additionalProperties": false,
+            "required": ["type", "format"]
+        },
+        "variantsAsList": {
+            "type": "object",
+            "properties": {
+                "type": {
+                    "const": "array"
+                },
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "type": {
+                            "const": "object"
+                        },
+                        "properties": { "$ref": "#/$defs/variantsProperty" },
+                        "required": { "$ref": "#/$defs/requiredConstraint" }
+                    },
+                    "additionalProperties": false
+                }
+            },
+            "additionalProperties": false,
+            "required": ["type", "items"]
+        },
+        "variantsProperty": {
+            "type": "object",
+            "properties": {
+                "uuid": { "$ref": "#/$defs/uuidProperty" }
+            },
+            "additionalProperties": { "$ref": "#/$defs/property" },
+            "default": {},
+            "required": ["uuid"],
+            "patternProperties": {
+                "^(axis_([1-9]|10))+$": {
+                    "type": "object",
+                    "allOf": [
+                        { "$ref": "#/$defs/property" },
+                        {
+                            "properties": {
+                                "type": {
+                                    "enum": ["string", "number", "boolean"]
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        "requiredConstraint": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            },
+            "uniqueItems": true,
+            "default": [],
+            "minItems": 1
+        },
+        "format": {
+            "enum": ["date-time", "uri"]
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "maxLength": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "minLength": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "enum": {
+            "type": "array"
+        }
+    },
+    "additionalProperties": false
+}


### PR DESCRIPTION
Added new version `0.3.0` for catalogs meta-schema and updated schema example.