### PR TITLE
Update PHP-client/products-uuid.md

### DIFF
--- a/content/php-client/resources/products/products-uuid.md
+++ b/content/php-client/resources/products/products-uuid.md
@@ -1,7 +1,7 @@
 ### Product UUID
 
 ::: info
-The following endpoints are largely the same as for [products](/php-client/resources.html#products). The difference? Here, you can query, create or update products identified by their uuid. More information [here](/content/getting-started/from-identifiers-to-uuid-7x/welcome.html).
+The following endpoints are largely the same as for [products](/php-client/resources.html#products). The difference? Here, you can query, create or update products identified by their uuid. More information [here](/getting-started/from-identifiers-to-uuid-7x/welcome.html).
 :::
 
 #### Get a product

--- a/content/php-client/resources/products/products-uuid.md
+++ b/content/php-client/resources/products/products-uuid.md
@@ -1,7 +1,7 @@
 ### Product UUID
 
 ::: info
-The following endpoints are largely the same as for [products](/php-client/resources.html#products). The difference? Here, you can query, create or update products identified by their uuid. More information [here](/content/getting-started/from-identifiers-to-uuid-7x/welcome.md).
+The following endpoints are largely the same as for [products](/php-client/resources.html#products). The difference? Here, you can query, create or update products identified by their uuid. More information [here](/content/getting-started/from-identifiers-to-uuid-7x/welcome.html).
 :::
 
 #### Get a product


### PR DESCRIPTION
From Slack: https://akeneo.slack.com/archives/C03HPGN4U/p1702994345029999

There is a broken link in this page
https://api.akeneo.com/php-client/resources.html#product-uuid The link https://api.akeneo.com/content/getting-started/from-identifiers-to-uuid-7x/welcome.md should refer to https://api.akeneo.com/getting-started/from-identifiers-to-uuid-7x/welcome.html