### PR TITLE
fix typos in API docs: some elements are incorrectly named _items

### DIFF
--- a/content/swagger/resources/asset_families/routes/asset_families.yaml
+++ b/content/swagger/resources/asset_families/routes/asset_families.yaml
@@ -43,7 +43,7 @@ get:
           }
         },
         _embedded: {
-          _items: [
+          items: [
             {
               "_links": {
                 "self": {

--- a/content/swagger/resources/assets/routes/assets.yaml
+++ b/content/swagger/resources/assets/routes/assets.yaml
@@ -42,7 +42,7 @@ get:
               _embedded:
                 type: object
                 properties:
-                  _items:
+                  items:
                     type: array
                     items:
                       $ref: '#/definitions/AssetList'
@@ -59,7 +59,7 @@ get:
           }
         },
         _embedded: {
-          _items: [
+          items: [
             {
               "_links": {
                 "self": {


### PR DESCRIPTION
Hi,

I recently stumbled upon those small errors, some elements are incorrectly documented as `_items` when the API returns `items`.

Thanks!