### PR TITLE
[CPM-1674] Update API doc to encourage users to use Product UUID endpoint

### DIFF
--- a/content/swagger/paths.yaml
+++ b/content/swagger/paths.yaml
@@ -1,12 +1,3 @@
-/api/rest/v1/products:
-  $ref: ./resources/products/routes/products.yaml
-/api/rest/v1/products/{code}:
-  $ref: ./resources/products/routes/products_code.yaml
-/api/rest/v1/products/{code}/proposal:
-  $ref: ./resources/products/routes/products_code_proposal.yaml
-/api/rest/v1/products/{code}/draft:
-  $ref: ./resources/products/routes/products_code_draft.yaml
-
 /api/rest/v1/products-uuid:
   $ref: ./resources/products_uuid/routes/products_uuid.yaml
 /api/rest/v1/products-uuid/{uuid}:
@@ -15,6 +6,15 @@
   $ref: ./resources/products_uuid/routes/products_uuid_uuid_proposal.yaml
 /api/rest/v1/products-uuid/{uuid}/draft:
   $ref: ./resources/products_uuid/routes/products_uuid_uuid_draft.yaml
+
+/api/rest/v1/products:
+  $ref: ./resources/products/routes/products.yaml
+/api/rest/v1/products/{code}:
+  $ref: ./resources/products/routes/products_code.yaml
+/api/rest/v1/products/{code}/proposal:
+  $ref: ./resources/products/routes/products_code_proposal.yaml
+/api/rest/v1/products/{code}/draft:
+  $ref: ./resources/products/routes/products_code_draft.yaml
 
 /api/rest/v1/product-models:
   $ref: ./resources/product_models/routes/product_models.yaml

--- a/src/api-reference/index.handlebars
+++ b/src/api-reference/index.handlebars
@@ -74,6 +74,16 @@
                                     We recommend exploring alternative solutions. <a target="_blank" href="https://help.akeneo.com/en_US/serenity-take-the-power-over-your-products/important-update-deprecation-of-the-published-products-feature-from-akeneo-pim">Learn more in the help center.</a></p>
                             </div>
                         {{/if}}
+                        {{#if isProductIdentifierOrUUID}}
+                            <a class="anchor" id="{{{categoryId}}}"></a>
+                            <div class="alert alert-warning">
+                                <p>This API provides two endpoints for interacting with products:</p>
+                                <ul>
+                                    <li><b><a href="/api-reference-index.html#Productuuid">Product (UUID):</a></b> We strongly recommend using this endpoint for its reliability and flexibility. UUIDs, or Universally Unique Identifiers, are guaranteed to be unique and never change, even if other product identifiers like SKUs are modified. This ensures consistent product identification regardless of future changes. Additionally, UUIDs allow interaction with products that lack a traditional identifier.</li>
+                                    <li><b><a href="/api-reference-index.html#Productidentifier">Product (Identifier):</a></b> This endpoint is useful when you already have a product identifier within your systems. This identifier, which could be a SKU or internal code, can be used to directly interact with the corresponding product in our API. This simplifies integration for workflows that rely on existing product identification methods.</li>
+                                </ul>
+                            </div>
+                        {{/if}}
                         <div class="list-group">
                             {{#each resource.operations as |operation operationId|}}
                                 <a class="list-group-item" href="{{../../../htmlReferencefileName}}.html#{{{operationId}}}">

--- a/src/api-reference/reference.handlebars
+++ b/src/api-reference/reference.handlebars
@@ -90,6 +90,16 @@
                                     We recommend exploring alternative solutions. <a target="_blank" href="https://help.akeneo.com/en_US/serenity-take-the-power-over-your-products/important-update-deprecation-of-the-published-products-feature-from-akeneo-pim">Learn more in the help center.</a></p>
                             </div>
                         {{/if}}
+                        {{#if isProductIdentifierOrUUID}}
+                            <a class="anchor" id="{{{categoryId}}}"></a>
+                            <div class="alert alert-warning">
+                                <p>This API provides two endpoints for interacting with products:</p>
+                                <ul>
+                                    <li><b><a href="/api-reference.html#Productuuid">Product (UUID):</a></b> We strongly recommend using this endpoint for its reliability and flexibility. UUIDs, or Universally Unique Identifiers, are guaranteed to be unique and never change, even if other product identifiers like SKUs are modified. This ensures consistent product identification regardless of future changes. Additionally, UUIDs allow interaction with products that lack a traditional identifier.</li>
+                                    <li><b><a href="/api-reference.html#Productidentifier">Product (Identifier):</a></b> This endpoint is useful when you already have a product identifier within your systems. This identifier, which could be a SKU or internal code, can be used to directly interact with the corresponding product in our API. This simplifies integration for workflows that rely on existing product identification methods.</li>
+                                </ul>
+                            </div>
+                        {{/if}}
                         <div id="{{{resource}}}-detail"></div>
                         {{#each resource.operations as |operation operationId|}}
                             <div class="panel panel-default">

--- a/tasks/reference.js
+++ b/tasks/reference.js
@@ -147,6 +147,9 @@ gulp.task('reference', ['clean-dist', 'less'], function() {
                             if(category.includes('Published products')) {
                                 data.categories[escapeCategory].isPublishedProduct = true;
                             }
+                            if(escapeTag.includes('Productidentifier') || escapeTag.includes('Productuuid')) {
+                                data.categories[escapeCategory].resources[escapeTag].isProductIdentifierOrUUID = true;
+                            }
                             data.categories[escapeCategory].resources[escapeTag].operations[operation.operationId] = _.extend(operation, {
                                 verb: verb,
                                 path: pathUri
@@ -197,6 +200,9 @@ gulp.task('reference', ['clean-dist', 'less'], function() {
                             }
                             if(category.includes('Published products')) {
                                 data.categories[escapeCategory].isPublishedProduct = true;
+                            }
+                            if(escapeTag.includes('Productidentifier') || escapeTag.includes('Productuuid')) {
+                                data.categories[escapeCategory].resources[escapeTag].isProductIdentifierOrUUID = true;
                             }
                             var groupedParameters = _.groupBy(operation.parameters, function(parameter) {
                                 return parameter.in;


### PR DESCRIPTION
The PR is deployed on https://pr-899.api-dev.akeneo.com/

## The order of the 2 endpoints as inversed
![image](https://github.com/akeneo/pim-api-docs/assets/137794770/c5a7e58e-063c-4f83-a289-96fb93f6de87)


## The message was added on the homepage of Rest API

![image](https://github.com/akeneo/pim-api-docs/assets/137794770/43cf8826-4f5f-44ac-80a2-9e872f619f5a)
![image](https://github.com/akeneo/pim-api-docs/assets/137794770/4cb9fb04-43cf-4cf2-accc-5e95b5131818)


## And also on the head of the detail endpoint 
![image](https://github.com/akeneo/pim-api-docs/assets/137794770/64e8fbce-c20c-4e3a-aaec-7091ee1ca297)

![image](https://github.com/akeneo/pim-api-docs/assets/137794770/7f79dbdd-7e3a-4821-bb52-c97d9a9efd2d)

