### PR TITLE
Update docker image for CI jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -201,7 +201,7 @@ jobs:
 
   build:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
     steps:
       - attach_workspace:
           at: ~/


### PR DESCRIPTION
**Description**

Current image used is deprecated. 

`ubuntu-2204:2022.07.1` => `ubuntu-2204:current`