### PR TITLE
fix(cha-937): disable indexing of non-production environments

### DIFF
--- a/deployments/modules/services/networking/backend-bucket.tf
+++ b/deployments/modules/services/networking/backend-bucket.tf
@@ -1,6 +1,7 @@
 resource "google_compute_backend_bucket" "front" {
-  name        = "${local.context}-bb"
-  description = "Contains static files"
-  bucket_name = var.bucket_name
-  enable_cdn  = true
+  name                    = "${local.context}-bb"
+  description             = "Contains static files"
+  bucket_name             = var.bucket_name
+  enable_cdn              = true
+  custom_response_headers = var.stage == "prd" ? [] : ["X-Robots-Tag: noindex"]
 }


### PR DESCRIPTION
```
➜  pim-api-docs git:(CHA-937-disable-indexing-of-non-production-environments-for-pim-api-documentation) curl --head https://pr-946.api-dev.akeneo.com                       
HTTP/2 200 
date: Fri, 20 Sep 2024 10:41:20 GMT
last-modified: Fri, 20 Sep 2024 10:29:19 GMT
etag: "48fa2a79b5f66af7eab001b962f30daa"
x-goog-generation: 1726828159705456
x-goog-metageneration: 1
x-goog-stored-content-encoding: identity
x-goog-stored-content-length: 40386
x-goog-meta-goog-reserved-file-mtime: 1726828006
content-type: text/html
x-goog-hash: crc32c=jabFDw==
x-goog-hash: md5=SPoqebX2avfqsAG5YvMNqg==
x-goog-storage-class: STANDARD
accept-ranges: bytes
content-length: 40386
x-guploader-uploadid: AD-8lju7-AgZUCN3TKd3rg4YNv-qWj9TPwIGK874O7mK3_lTeMMymQk9CRxhG4cX84j8l7PD9eg
server: UploadServer
cache-control: public,max-age=3600
x-robots-tag: noindex
alt-svc: h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
```