### PR TITLE
PIM-12026 [Security] Add SSL policy to use only TLS 1.2

### DIFF
--- a/deployments/modules/services/networking/load-balancer.tf
+++ b/deployments/modules/services/networking/load-balancer.tf
@@ -25,10 +25,17 @@ resource "google_compute_managed_ssl_certificate" "default" {
   }
 }
 
+resource "google_compute_ssl_policy" "default" {
+  name            = "default-ssl-tls-policy"
+  profile         = "COMPATIBLE"
+  min_tls_version = "TLS_1_2"
+}
+
 resource "google_compute_target_https_proxy" "default" {
   name             = "${local.context}-https-lb-proxy"
   url_map          = google_compute_url_map.default.id
   ssl_certificates = [google_compute_managed_ssl_certificate.default.id]
+  ssl_policy       = google_compute_ssl_policy.default.id
 }
 
 resource "google_compute_target_http_proxy" "https_redirect" {


### PR DESCRIPTION
api.akeneo.com uses TLS 1.0 and TLS 1.1 which are now deprecated.
This PR force the use of TLS 1.2 for api.akeneo.com

- Create a new default SSL policy with TLS 1.2 and [COMPATIBLE](https://cloud.google.com/load-balancing/docs/ssl-policies-concepts#profilefeaturesupport:~:text=Allows%20the%20broadest%20set%20of%20clients%2C%20including%20clients%20that%20support%20only%20out%2Dof%2Ddate%20SSL%20features%2C%20to%20negotiate%20SSL%20with%20the%20load%20balancer.) profile (Allows the broadest set of clients to not reject potentials out-of-date SSL clients)
- Link the load balancer to use this default SSL policy

Testing:

Using `docker run --rm -it nablac0d3/sslyze`
Before: 
![image](https://github.com/user-attachments/assets/dc5e42a5-dd12-4ad9-9cec-1d0065b90236)
After:
![image](https://github.com/user-attachments/assets/d2e09c29-9f49-4895-a290-7913ea6cde25)
No more TLS version error.