### PR TITLE
CHA-1452 Event-Platform Update http subscription delivery policy

### DIFF
--- a/content/event-platform/concepts.md
+++ b/content/event-platform/concepts.md
@@ -51,6 +51,11 @@ The statuses for a subscription are:
 
 ## Subscription types
 
+::: info
+We will consider adding other subscription destinations based on feedback. Please [fill-in this form](https://forms.gle/XsZ7rovRnqfAn4xF9) to propose & upvote new destination types.
+:::
+
+
 ### Pub/Sub subscription
 
 #### Configuration

--- a/content/event-platform/concepts.md
+++ b/content/event-platform/concepts.md
@@ -58,6 +58,14 @@ We will consider adding other subscription destinations based on feedback. Pleas
 
 ### Pub/Sub subscription
 
+This is the **preferred and most resilient method** for consuming events. It leverages Google Cloud's managed messaging service.
+
+#### Key Advantages
+
+- **Managed Scalability & Reliability:** Google Pub/Sub inherently handles high throughput and traffic bursts, absorbing the complexities of scaling.
+- **Reduced Infrastructure Burden:** Significantly lowers the operational overhead and risk for the customer.
+- **Simplified Integration:** Easier setup and maintenance compared to managing a custom HTTP endpoint.
+
 #### Configuration
 
 For the `pubsub` subscription type, the `config` property needed when creating the subscription requires both the project ID and the topic ID.
@@ -94,6 +102,25 @@ For some configuration, you might also need our GCP project number : `9735664330
 For comprehensive details on managing subscriptions, consult the complete API reference [here](/event-platform/api-reference.html).
 
 ### HTTPS subscription
+
+This option pushes events directly to a HTTP endpoint. It offers flexibility but requires careful infrastructure planning.
+
+#### Critical Requirements & Considerations
+
+- **Strong Infrastructure:** The endpoint must be highly available and designed to handle variable event loads.
+    - This also depends on the **source PIM's size and activity**. A small PIM with few SKUs won't generate the same volume as a large instance with many jobs. Thus, the **HTTP endpoint** can be adjusted based on the PIM's intended use.
+- **Mandatory Rate Limiting (HTTP 429):**
+    - Our platform **dynamically adjusts its delivery rate from 1 to 100 events per second.**
+    - This adaptive mechanism **relies entirely on the endpoint correctly returning an `HTTP 429 "Too Many Requests"` status** when its capacity is reached. [ref](https://api.akeneo.com/event-platform/key-platform-behaviors.html#optimized-throughput)
+
+::: warning
+Endpoints without proper HTTP 429 handling are at high risk of being overwhelmed, leading to event loss and subscription suspension.
+:::
+
+- **Fast Acknowledgement:** Endpoints must respond with an `HTTP 200 OK` within **5 seconds**. Delays trigger retries and can lead to suspension. [ref](https://api.akeneo.com/event-platform/key-platform-behaviors.html#delivery-timeout)
+    - **Recommendation:** Implement an asynchronous processing model (e.g., using an internal queue) to acknowledge events quickly and process them separately.
+- **Suspension Policy:** Subscriptions may be suspended due to repeated errors (e.g., `4xx`/`5xx` status codes, timeouts, misconfigured SSL). [ref](https://api.akeneo.com/event-platform/key-platform-behaviors.html#suspension-policy)
+
 
 #### Configuration
 
@@ -181,6 +208,8 @@ We currently use a static IP address provided by Google Cloud: `34.140.80.128`
 ## Subscription Filters
 
 When configuring a subscription, you can optionally define a **filter** to receive **only the events that match specific criteria**.
+
+**Regardless of the destination type, we strongly advise to utilize event filters.** This ensures you only subscribe to and receive events that are relevant to your specific integration needs.
 
 You can find the list of currently available filters and the correct syntax to use [here](/event-platform/available-filters.html).
 

--- a/content/event-platform/key-platform-behaviors.md
+++ b/content/event-platform/key-platform-behaviors.md
@@ -15,7 +15,7 @@ To help identify duplicated events and deal with un-ordered events if it's somet
 
 If your subscription has an HTTPS destination, our delivery engine adapts the event delivery rate based on your system's capacity, operating within these limits:
 
-**Maximum rate:** `100` events per second (default rate)
+**Maximum rate:** `100` events per second
 
 **Minimum rate:** `1` event per second
 

--- a/content/event-platform/key-platform-behaviors.md
+++ b/content/event-platform/key-platform-behaviors.md
@@ -23,7 +23,7 @@ The throughput automatically adjusts between these limits based on your endpoint
 - `200 OK`: The delivery rate gradually increases up to the maximum rate
 - `429 Too Many Requests`: The delivery rate decreases to prevent system overload
 
-> **⚠️ Important**: Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate. This can trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy) as it indicates a potential queuing risk.
+Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate. This can trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy) as it indicates a potential queuing risk.
 
 ## Delivery timeout
 
@@ -58,7 +58,7 @@ Your subscription is immediately suspended if you meet one of these conditions:
 
 ### Threshold-Based Suspension:
 
-This type of suspension is based on the success rate of your HTTPS endpoint. If the success rate drops below 95% within the last rolling hour, your subscription will be suspended.
+This type of suspension is based on the success rate of your HTTPS endpoint. If the success rate drops below 90% within the last rolling hour, your subscription will be suspended.
 
 Here are the errors type that decrease the success rate:
 

--- a/content/event-platform/key-platform-behaviors.md
+++ b/content/event-platform/key-platform-behaviors.md
@@ -15,7 +15,7 @@ To help identify duplicated events and deal with un-ordered events if it's somet
 
 If your subscription has an HTTPS destination, our delivery engine adapts the event delivery rate based on your system's capacity, operating within these limits:
 
-**Maximum rate:** `100` events per second
+**Maximum rate:** `100` events per second (default rate)
 
 **Minimum rate:** `1` event per second
 
@@ -23,7 +23,10 @@ If your subscription has an HTTPS destination, our delivery engine adapts the ev
 The throughput automatically adjusts between these limits based on your endpoint's responses:
 - `200 OK`: The delivery rate gradually increases up to the maximum rate
 - `429 Too Many Requests`: The delivery rate decreases to prevent system overload
-  - ⚠️ Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate, as it indicates a potential queuing risk. This may trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy).
+
+::: warning
+Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate, as it indicates a potential queuing risk. This may trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy).
+:::
 
 If your system is struggling to handle high HTTP throughput, consider using another [subscription type](/event-platform/concepts.html#subscription-types).
 

--- a/content/event-platform/key-platform-behaviors.md
+++ b/content/event-platform/key-platform-behaviors.md
@@ -28,7 +28,7 @@ The throughput automatically adjusts between these limits based on your endpoint
 Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate, as it indicates a potential queuing risk. This may trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy).
 :::
 
-If your system is struggling to handle high HTTP throughput, consider using another [subscription type](/event-platform/concepts.html#subscription-types).
+Consider using another [subscription type](/event-platform/concepts.html#subscription-types) to get around these limitations.
 
 
 ## Delivery timeout

--- a/content/event-platform/key-platform-behaviors.md
+++ b/content/event-platform/key-platform-behaviors.md
@@ -15,15 +15,18 @@ To help identify duplicated events and deal with un-ordered events if it's somet
 
 If your subscription has an HTTPS destination, our delivery engine adapts the event delivery rate based on your system's capacity, operating within these limits:
 
-- `Maximum rate:` 100 events per second
+**Maximum rate:** `100` events per second
 
-- `Minimum rate:` 1 event per second
+**Minimum rate:** `1` event per second
+
 
 The throughput automatically adjusts between these limits based on your endpoint's responses:
 - `200 OK`: The delivery rate gradually increases up to the maximum rate
 - `429 Too Many Requests`: The delivery rate decreases to prevent system overload
+  - ⚠️ Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate, as it indicates a potential queuing risk. This may trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy).
 
-Events that are throttled and remain undelivered for more than one hour will negatively impact your success rate. This can trigger the [suspension policy](/event-platform/key-platform-behaviors.html#suspension-policy) as it indicates a potential queuing risk.
+If your system is struggling to handle high HTTP throughput, consider using another [subscription type](/event-platform/concepts.html#subscription-types).
+
 
 ## Delivery timeout
 
@@ -63,7 +66,7 @@ This type of suspension is based on the success rate of your HTTPS endpoint. If 
 Here are the errors type that decrease the success rate:
 
 - `5XX Server Error` HTTP statuses
-- `429 Too Many Requests` HTTP statuses (while the event  remains undelivered for more than one hour)
+- `429 Too Many Requests` HTTP statuses (while the event remains undelivered for more than one hour)
 - `4xx Client Error Response` HTTP status
 - Delivery timeout
 


### PR DESCRIPTION
Whats changed:
1. Info pane to suggest using the queuing subscription type form
<img width="866" alt="image" src="https://github.com/user-attachments/assets/f876b044-b73b-4a23-a89d-a0d360f6ad6b" />
2. Delivery rate policy clarification
<img width="866" alt="image" src="https://github.com/user-attachments/assets/67656adf-5d86-43ed-bf02-08f7f4cb5766" />

<img width="891" alt="image" src="https://github.com/user-attachments/assets/5f097073-4e42-4ca5-b2fe-a7822351a120" />

<img width="891" alt="image" src="https://github.com/user-attachments/assets/15b7dfe5-0ee1-485a-b811-f077855bbb92" />
