### PR TITLE
Add workflow endpoints to postman collection

### DIFF
--- a/content/files/Akeneo PIM API.postman_collection.json
+++ b/content/files/Akeneo PIM API.postman_collection.json
@@ -2285,7 +2285,6 @@
 							},
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
 								"value": "application/json",
 								"type": "text"
 							}
@@ -2959,9 +2958,8 @@
 							},
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
-								"type": "text",
-								"value": "application/json"
+								"value": "application/json",
+								"type": "text"
 							}
 						],
 						"body": {
@@ -3141,7 +3139,6 @@
 							},
 							{
 								"key": "Content-Type",
-								"name": "Content-Type",
 								"value": "application/json",
 								"type": "text"
 							}
@@ -5049,7 +5046,7 @@
 							}
 						],
 						"url": {
-							"raw": "{{url}}/api/rest/v1/jobs/export/csv_product_export",
+							"raw": "{{url}}/api/rest/v1/jobs/export",
 							"host": [
 								"{{url}}"
 							],
@@ -5083,7 +5080,7 @@
 							"raw": "{\n  \"import_mode\": \"create_only\"\n}"
 						},
 						"url": {
-							"raw": "{{url}}/api/rest/v1/jobs/import/csv_product_import",
+							"raw": "{{url}}/api/rest/v1/jobs/import",
 							"host": [
 								"{{url}}"
 							],
@@ -5095,6 +5092,328 @@
 								"import"
 							]
 						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Extensions",
+			"item": [
+				{
+					"name": "UI Extension",
+					"item": [
+						{
+							"name": "List extensions",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"// Validate if response header has matching content-type\npm.test(\"[GET]::/api/rest/v1/ui-extensions - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+											"// Validate if response has JSON Body \npm.test(\"[GET]::/api/rest/v1/ui-extensions - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+											"// Response Validation\nconst schema = {\"type\":\"array\",\"description\":\"Represents a list of extensions\",\"items\":{\"anyOf\":[{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.header\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\"]},\"type\":{\"type\":\"string\",\"default\":\"link\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.tab\",\"pim.category.tab\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"action\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/rest/v1/ui-extensions - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+										]
+									}
+								}
+							],
+							"request": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"url": {
+									"raw": "{{url}}/api/rest/v1/ui-extensions",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"rest",
+										"v1",
+										"ui-extensions"
+									]
+								},
+								"description": "List all extensions associated with your token"
+							},
+							"response": []
+						},
+						{
+							"name": "Add an extension",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"// Validate if response header has matching content-type\npm.test(\"[POST]::/api/rest/v1/ui-extensions - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+											"// Validate if response has JSON Body \npm.test(\"[POST]::/api/rest/v1/ui-extensions - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+											"// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.header\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\"]},\"status\":{\"type\":\"string\",\"default\":\"active\"},\"type\":{\"type\":\"string\",\"default\":\"link\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.tab\",\"pim.category.tab\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"action\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/rest/v1/ui-extensions - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+										]
+									}
+								}
+							],
+							"request": {
+								"method": "POST",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"my_awesome_button_extension\",\n  \"version\": \"V1.02.3\",\n  \"description\": \"A short human readable description.\",\n  \"position\": \"pim.product.header\",\n  \"type\": \"link\",\n  \"configuration\": {\n    \"url\": \"https://www.example.com\",\n    \"default_label\": \"My awesome link extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome link extension\",\n      \"fr_FR\": \"Ma super link extension\"\n    }\n  }\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{url}}/api/rest/v1/ui-extensions",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"rest",
+										"v1",
+										"ui-extensions"
+									]
+								},
+								"description": "The `configuration` depends on the `position`. Available positions are `pim.product.tab`, `pim.category.tab` and `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header`, `pim.product-grid.action-bar`.\nFor now, the only configuration keys are the same for all the position.\n\nThe `type` available are `iframe`, `link` and `action`. It depends on the `position` :\n- `iframe` for `pim.product.tab`, `pim.category.tab` and `pim.product-grid.action-bar`\n- `link` for `pim.product.header`, `pim.product-model.header` and `pim.sub-product-model.header`\n- `action` for `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header` and `pim.product-grid.action-bar`\n"
+							},
+							"response": []
+						},
+						{
+							"name": "Update an extension",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"// Validate if response header has matching content-type\npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
+											"// Validate if response has JSON Body \npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
+											"// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.header\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\"]},\"status\":{\"type\":\"string\",\"default\":\"active\"},\"type\":{\"type\":\"string\",\"default\":\"link\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.tab\",\"pim.category.tab\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"action\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
+										]
+									}
+								}
+							],
+							"request": {
+								"method": "PATCH",
+								"header": [
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									},
+									{
+										"key": "Accept",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n  \"name\": \"my_awesome_button_extension\",\n  \"version\": \"V1.02.3\",\n  \"description\": \"A short human readable description.\",\n  \"position\": \"pim.product.header\",\n  \"type\": \"link\",\n  \"configuration\": {\n    \"url\": \"https://www.example.com\",\n    \"default_label\": \"My awesome link extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome link extension\",\n      \"fr_FR\": \"Ma super link extension\"\n    }\n  }\n}",
+									"options": {
+										"raw": {
+											"headerFamily": "json",
+											"language": "json"
+										}
+									}
+								},
+								"url": {
+									"raw": "{{url}}/api/rest/v1/ui-extensions/:ui_extension_uuid",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"rest",
+										"v1",
+										"ui-extensions",
+										":ui_extension_uuid"
+									],
+									"variable": [
+										{
+											"key": "ui_extension_uuid",
+											"value": "e175d525-8fbf-4b26-9242-1daccf301f8b",
+											"description": "(Required) "
+										}
+									]
+								},
+								"description": "The `configuration` depends on the `position`. Available positions are `pim.product.tab`, `pim.category.tab` and `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header`, `pim.product-grid.action-bar`.\nFor now, the only configuration keys are the same for all the position.\n\nThe `type` available are `iframe`, `link` and `action`. It depends on the `position` :\n- `iframe` for `pim.product.tab`, `pim.category.tab` and `pim.product-grid.action-bar`\n- `link` for `pim.product.header`, `pim.product-model.header` and `pim.sub-product-model.header`\n- `action` for `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header` and `pim.product-grid.action-bar`\n"
+							},
+							"response": []
+						},
+						{
+							"name": "Delete an extension",
+							"event": [
+								{
+									"listen": "test",
+									"script": {
+										"type": "text/javascript",
+										"exec": [
+											"// Validate if response has empty Body \npm.test(\"[DELETE]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
+										]
+									}
+								}
+							],
+							"request": {
+								"method": "DELETE",
+								"header": [],
+								"url": {
+									"raw": "{{url}}/api/rest/v1/ui-extensions/:ui_extension_uuid",
+									"host": [
+										"{{url}}"
+									],
+									"path": [
+										"api",
+										"rest",
+										"v1",
+										"ui-extensions",
+										":ui_extension_uuid"
+									],
+									"variable": [
+										{
+											"key": "ui_extension_uuid",
+											"value": "e175d525-8fbf-4b26-9242-1daccf301f8b",
+											"description": "(Required) "
+										}
+									]
+								},
+								"description": "Delete an extension"
+							},
+							"response": []
+						}
+					],
+					"description": "Manipulate UI Extensions"
+				}
+			],
+			"auth": {
+				"type": "bearer",
+				"bearer": [
+					{
+						"key": "token",
+						"value": "{{pim_access_token}}",
+						"type": "string"
+					}
+				]
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"type": "text/javascript",
+						"exec": [
+							"/*\n For simplicity, we acquire a new token before each API call.\n This is not recommended to do the same in production. \n \n Benefit from the 1 hour validity of the access_token and leverage the refresh_token grant type.\n Explore the official PIM API documentation for details https://api.akeneo.com/documentation/authentication.html\n\n*/\n\nappAccessToken = pm.environment.get(\"app_access_token\")\nif (appAccessToken!==undefined) {\n    pm.environment.set(\"pim_access_token\", appAccessToken)\n    console.log(\"Used the token provided in the \\\"app_access_token\\\" variable instead of authenticating with the PIM.\")\n    return\n}\n\nbase64ClientIdSecret = require('btoa')(pm.environment.get(\"clientId\") + ':' + pm.environment.get(\"secret\"))\n\npm.sendRequest({\n    url: pm.environment.get(\"url\").replace(/\\/$/, '') + '/api/oauth/v1/token',\n    method: 'POST',\n    header: {\n        'Authorization': 'Basic ' + base64ClientIdSecret,\n        'Content-Type': 'application/json',\n    },\n    body: {\n        mode: 'raw',\n        raw: JSON.stringify(\n            {\n                \"username\" : pm.environment.get(\"username\"),\n                \"password\" : pm.environment.get(\"password\"),\n                \"grant_type\": \"password\"\n            }\n        )\n    }\n}, function (err, res) {\n    if(err !== null ){\n        console.error(\"The following error occured during pre-script execution\");\n        console.error(err);\n        return;\n    }\n    console.warn(\"For simplicity, we acquire a new token before each API call, this is not recommended in production. Benefit from the 1 hour validity of the access_token.\");\n    pm.environment.set(\"pim_access_token\", res.json().access_token);\n});"
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Workflow",
+			"item": [
+				{
+					"name": "Get a workflow",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/rest/v1/workflows/:uuid",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"rest",
+								"v1",
+								"workflows",
+								":uuid"
+							],
+							"variable": [
+								{
+									"key": "uuid",
+									"value": "",
+									"description": "(string) • Uuid of the Workflow"
+								}
+							]
+						},
+						"description": "Assuming that the given identifier is the identifier of an existing product"
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of workflow step assignees",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							},
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							},
+							{
+								"key": "Cookie",
+								"value": ""
+							}
+						],
+						"url": {
+							"raw": "{{url}}/api/rest/v1/workflows/steps/:uuid/assignees",
+							"host": [
+								"{{url}}"
+							],
+							"path": [
+								"api",
+								"rest",
+								"v1",
+								"workflows",
+								"steps",
+								":uuid",
+								"assignees"
+							],
+							"query": [
+								{
+									"key": "page",
+									"value": "1",
+									"description": "(integer , 1 by default ) • Number of the page to retrieve when using the `page` pagination method type.",
+									"disabled": true
+								},
+								{
+									"key": "limit",
+									"value": "10",
+									"description": "(integer , 10 by default )  • Number of results by page.",
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "uuid",
+									"value": "",
+									"description": "(string) • Uuid of the Workflow Step"
+								}
+							]
+						},
+						"description": "\n"
 					},
 					"response": []
 				}
@@ -5216,331 +5535,6 @@
 				}
 			},
 			"response": []
-		},
-		{
-			"name": "Extensions",
-			"item": [
-				{
-					"id": "c662362d-06c3-4ba7-8458-c6b0f9b4fb7e",
-					"name": "UI Extension",
-					"description": {
-						"content": "Manipulate UI Extensions",
-						"type": "text/plain"
-					},
-					"item": [
-						{
-							"id": "5e248299-994a-477d-b105-a6087d727084",
-							"name": "List extensions",
-							"request": {
-								"name": "List extensions",
-								"description": {
-									"content": "List all extensions associated with your token",
-									"type": "text/plain"
-								},
-								"url": {
-									"path": [
-										"api",
-										"rest",
-										"v1",
-										"ui-extensions"
-									],
-									"host": [
-										"{{url}}"
-									],
-									"query": [],
-									"variable": []
-								},
-								"header": [
-									{
-										"key": "Accept",
-										"value": "application/json"
-									}
-								],
-								"method": "GET",
-								"body": {}
-							},
-							"response": [],
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "4003f1b6-4cab-4220-af16-9d4ae3f5f79f",
-										"type": "text/javascript",
-										"exec": [
-											"// Validate if response header has matching content-type\npm.test(\"[GET]::/api/rest/v1/ui-extensions - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-											"// Validate if response has JSON Body \npm.test(\"[GET]::/api/rest/v1/ui-extensions - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-											"// Response Validation\nconst schema = {\"type\":\"array\",\"description\":\"Represents a list of extensions\",\"items\":{\"anyOf\":[{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.header\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\"]},\"type\":{\"type\":\"string\",\"default\":\"link\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.tab\",\"pim.category.tab\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"action\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}}\n\n// Validate if response matches JSON schema \npm.test(\"[GET]::/api/rest/v1/ui-extensions - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
-										]
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							}
-						},
-						{
-							"id": "3b46895f-2870-45c4-9b7f-b000c751f273",
-							"name": "Add an extension",
-							"request": {
-								"name": "Add an extension",
-								"description": {
-									"content": "The `configuration` depends on the `position`. Available positions are `pim.product.tab`, `pim.category.tab` and `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header`, `pim.product-grid.action-bar`.\nFor now, the only configuration keys are the same for all the position.\n\nThe `type` available are `iframe`, `link` and `action`. It depends on the `position` :\n- `iframe` for `pim.product.tab`, `pim.category.tab` and `pim.product-grid.action-bar`\n- `link` for `pim.product.header`, `pim.product-model.header` and `pim.sub-product-model.header`\n- `action` for `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header` and `pim.product-grid.action-bar`\n",
-									"type": "text/plain"
-								},
-								"url": {
-									"path": [
-										"api",
-										"rest",
-										"v1",
-										"ui-extensions"
-									],
-									"host": [
-										"{{url}}"
-									],
-									"query": [],
-									"variable": []
-								},
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "Accept",
-										"value": "application/json"
-									}
-								],
-								"method": "POST",
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"name\": \"my_awesome_button_extension\",\n  \"version\": \"V1.02.3\",\n  \"description\": \"A short human readable description.\",\n  \"position\": \"pim.product.header\",\n  \"type\": \"link\",\n  \"configuration\": {\n    \"url\": \"https://www.example.com\",\n    \"default_label\": \"My awesome link extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome link extension\",\n      \"fr_FR\": \"Ma super link extension\"\n    }\n  }\n}",
-									"options": {
-										"raw": {
-											"headerFamily": "json",
-											"language": "json"
-										}
-									}
-								}
-							},
-							"response": [],
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "14ac44c5-ab3b-48e7-a8f6-faf9a1002c57",
-										"type": "text/javascript",
-										"exec": [
-											"// Validate if response header has matching content-type\npm.test(\"[POST]::/api/rest/v1/ui-extensions - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-											"// Validate if response has JSON Body \npm.test(\"[POST]::/api/rest/v1/ui-extensions - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-											"// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.header\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\"]},\"status\":{\"type\":\"string\",\"default\":\"active\"},\"type\":{\"type\":\"string\",\"default\":\"link\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.tab\",\"pim.category.tab\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"action\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[POST]::/api/rest/v1/ui-extensions - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
-										]
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							}
-						},
-						{
-							"id": "db7e1a5f-8832-4e30-93b3-74e945ee7090",
-							"name": "Update an extension",
-							"request": {
-								"name": "Update an extension",
-								"description": {
-									"content": "The `configuration` depends on the `position`. Available positions are `pim.product.tab`, `pim.category.tab` and `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header`, `pim.product-grid.action-bar`.\nFor now, the only configuration keys are the same for all the position.\n\nThe `type` available are `iframe`, `link` and `action`. It depends on the `position` :\n- `iframe` for `pim.product.tab`, `pim.category.tab` and `pim.product-grid.action-bar`\n- `link` for `pim.product.header`, `pim.product-model.header` and `pim.sub-product-model.header`\n- `action` for `pim.product.header`, `pim.product-model.header`, `pim.sub-product-model.header` and `pim.product-grid.action-bar`\n",
-									"type": "text/plain"
-								},
-								"url": {
-									"path": [
-										"api",
-										"rest",
-										"v1",
-										"ui-extensions",
-										":ui_extension_uuid"
-									],
-									"host": [
-										"{{url}}"
-									],
-									"query": [],
-									"variable": [
-										{
-											"disabled": false,
-											"description": {
-												"content": "(Required) ",
-												"type": "text/plain"
-											},
-											"type": "any",
-											"value": "e175d525-8fbf-4b26-9242-1daccf301f8b",
-											"key": "ui_extension_uuid"
-										}
-									]
-								},
-								"header": [
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									},
-									{
-										"key": "Accept",
-										"value": "application/json"
-									}
-								],
-								"method": "PATCH",
-								"body": {
-									"mode": "raw",
-									"raw": "{\n  \"name\": \"my_awesome_button_extension\",\n  \"version\": \"V1.02.3\",\n  \"description\": \"A short human readable description.\",\n  \"position\": \"pim.product.header\",\n  \"type\": \"link\",\n  \"configuration\": {\n    \"url\": \"https://www.example.com\",\n    \"default_label\": \"My awesome link extension\",\n    \"labels\": {\n      \"en_US\": \"My awesome link extension\",\n      \"fr_FR\": \"Ma super link extension\"\n    }\n  }\n}",
-									"options": {
-										"raw": {
-											"headerFamily": "json",
-											"language": "json"
-										}
-									}
-								}
-							},
-							"response": [],
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "2c067f12-0aff-4d52-82a0-7017f716f9e4",
-										"type": "text/javascript",
-										"exec": [
-											"// Validate if response header has matching content-type\npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Content-Type is application/json\", function () {\n   pm.expect(pm.response.headers.get(\"Content-Type\")).to.include(\"application/json\");\n});\n",
-											"// Validate if response has JSON Body \npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Response has JSON Body\", function () {\n    pm.response.to.have.jsonBody();\n});\n",
-											"// Response Validation\nconst schema = {\"oneOf\":[{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.header\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\"]},\"status\":{\"type\":\"string\",\"default\":\"active\"},\"type\":{\"type\":\"string\",\"default\":\"link\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.tab\",\"pim.category.tab\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"iframe\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}},{\"type\":\"object\",\"properties\":{\"uuid\":{\"type\":\"string\"},\"name\":{\"type\":\"string\"},\"version\":{\"type\":\"string\"},\"description\":{\"type\":\"string\"},\"position\":{\"type\":\"string\",\"default\":\"pim.product.tab\",\"enum\":[\"pim.product.header\",\"pim.product-model.header\",\"pim.sub-product-model.header\",\"pim.product-grid.action-bar\"]},\"type\":{\"type\":\"string\",\"default\":\"action\"},\"configuration\":{\"type\":\"object\",\"properties\":{\"url\":{\"type\":\"string\"},\"default_label\":{\"type\":\"string\"},\"labels\":{\"type\":\"object\",\"properties\":{\"en_US\":{\"type\":\"string\"},\"fr_FR\":{\"type\":\"string\"}}}}}}}]}\n\n// Validate if response matches JSON schema \npm.test(\"[PATCH]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Schema is valid\", function() {\n    pm.response.to.have.jsonSchema(schema,{unknownFormats: [\"int32\", \"int64\", \"float\", \"double\"]});\n});\n"
-										]
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							}
-						},
-						{
-							"id": "12addfe3-be97-4849-8756-bb714d713763",
-							"name": "Delete an extension",
-							"request": {
-								"name": "Delete an extension",
-								"description": {
-									"content": "Delete an extension",
-									"type": "text/plain"
-								},
-								"url": {
-									"path": [
-										"api",
-										"rest",
-										"v1",
-										"ui-extensions",
-										":ui_extension_uuid"
-									],
-									"host": [
-										"{{url}}"
-									],
-									"query": [],
-									"variable": [
-										{
-											"disabled": false,
-											"description": {
-												"content": "(Required) ",
-												"type": "text/plain"
-											},
-											"type": "any",
-											"value": "e175d525-8fbf-4b26-9242-1daccf301f8b",
-											"key": "ui_extension_uuid"
-										}
-									]
-								},
-								"method": "DELETE",
-								"body": {}
-							},
-							"response": [],
-							"event": [
-								{
-									"listen": "test",
-									"script": {
-										"id": "5cefbac5-a128-4e5d-8708-d1e2998b10a2",
-										"type": "text/javascript",
-										"exec": [
-											"// Validate if response has empty Body \npm.test(\"[DELETE]::/api/rest/v1/ui-extensions/:ui_extension_uuid - Response has empty Body\", function () {\n    pm.response.to.not.be.withBody;\n});\n"
-										]
-									}
-								}
-							],
-							"protocolProfileBehavior": {
-								"disableBodyPruning": true
-							}
-						}
-					],
-					"event": []
-				}
-			],
-			"auth": {
-				"type": "bearer",
-				"bearer": [
-					{
-						"type": "string",
-						"value": "{{pim_access_token}}",
-						"key": "token"
-					}
-				]
-			},
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"id": "afb8a117-ff18-410b-a14a-96754ce1ad87",
-						"type": "text/javascript",
-						"exec": [
-							"/*\n For simplicity, we acquire a new token before each API call.\n This is not recommended to do the same in production. \n \n Benefit from the 1 hour validity of the access_token and leverage the refresh_token grant type.\n Explore the official PIM API documentation for details https://api.akeneo.com/documentation/authentication.html\n\n*/\n\nappAccessToken = pm.environment.get(\"app_access_token\")\nif (appAccessToken!==undefined) {\n    pm.environment.set(\"pim_access_token\", appAccessToken)\n    console.log(\"Used the token provided in the \\\"app_access_token\\\" variable instead of authenticating with the PIM.\")\n    return\n}\n\nbase64ClientIdSecret = require('btoa')(pm.environment.get(\"clientId\") + ':' + pm.environment.get(\"secret\"))\n\npm.sendRequest({\n    url: pm.environment.get(\"url\").replace(/\\/$/, '') + '/api/oauth/v1/token',\n    method: 'POST',\n    header: {\n        'Authorization': 'Basic ' + base64ClientIdSecret,\n        'Content-Type': 'application/json',\n    },\n    body: {\n        mode: 'raw',\n        raw: JSON.stringify(\n            {\n                \"username\" : pm.environment.get(\"username\"),\n                \"password\" : pm.environment.get(\"password\"),\n                \"grant_type\": \"password\"\n            }\n        )\n    }\n}, function (err, res) {\n    if(err !== null ){\n        console.error(\"The following error occured during pre-script execution\");\n        console.error(err);\n        return;\n    }\n    console.warn(\"For simplicity, we acquire a new token before each API call, this is not recommended in production. Benefit from the 1 hour validity of the access_token.\");\n    pm.environment.set(\"pim_access_token\", res.json().access_token);\n});"
-						]
-					}
-				}
-			],
-			"variable": [
-				{
-					"type": "string",
-					"value": "https://pim-url.cloud.akeneo.com",
-					"key": "url"
-				},
-				{
-					"type": "string",
-					"value": "changeme",
-					"key": "clientId"
-				},
-				{
-					"type": "string",
-					"value": "changeme",
-					"key": "secret"
-				},
-				{
-					"type": "string",
-					"value": "changeme",
-					"key": "username"
-				},
-				{
-					"type": "string",
-					"value": "changeme",
-					"key": "password"
-				}
-			],
-			"info": {
-				"_postman_id": "b2d60d36-787b-404c-ba72-0492c30937ba",
-				"name": "Akeneo PIM UI Extension",
-				"version": {
-					"raw": "1.0.0",
-					"major": 1,
-					"minor": 0,
-					"patch": 0,
-					"prerelease": [],
-					"build": [],
-					"string": "1.0.0"
-				},
-				"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-				"description": {
-					"content": "Akeneo PIM UI extension endpoint manipulation",
-					"type": "text/plain"
-				}
-			}
 		}
 	],
 	"event": [


### PR DESCRIPTION
Note: Seems like postman ordered some endpoints differently when re-exporting so the diff is bigger.
Some `id` and `protocolProfileBehavior` properties have been automatically removed (~20 lines) and some variables (~10 lines)

<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/c8609ff8-160f-4ce4-90db-966bc821f98c" />

<img width="2560" height="1369" alt="image" src="https://github.com/user-attachments/assets/2d7d6d9d-39bf-4ef7-80c1-8fff66b14f7d" />
