### PR TITLE
CHA-1625: sync with deletion the pim-api-doc bucket (clean up non used files)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -244,7 +244,7 @@ jobs:
       - run:
           name: Run rsync between local sources and the target bucket
           command: |
-            gcloud storage rsync --recursive ~/dist gs://<<parameters.environment>>-${GOOGLE_CLOUD_PROJECT}-front
+            gcloud storage rsync --delete-unmatched-destination-objects --recursive ~/dist gs://<<parameters.environment>>-${GOOGLE_CLOUD_PROJECT}-front
 
   infrastructure: &infrastructure
     parameters:

--- a/content/apps/overview.md
+++ b/content/apps/overview.md
@@ -117,7 +117,7 @@ In short, everything you need to guide you in your app journey!
 Your app is good to go?
 
 - Read our [how to publish your app](/app-portal/publish-your-app.html) guide
-- Consult our recommendations about [how to write your app information](/app-portal/manage-app-information.html#app-identity-and-description)
+- Consult our recommendations about [how to write your app information](/app-portal/publish-your-app.html#your-app-must-have-comprehensive-information)
 
 ## Develop an app for a custom need
 

--- a/content/extensions/getting-started.md
+++ b/content/extensions/getting-started.md
@@ -2,7 +2,7 @@
 In this section, you will learn how to create your first UI Extension in under a minute. By following this quick guide, you'll gain the skills needed to effectively use the UI for creating and managing UI Extensions.
 
 ### Prerequisites
-Having the proper permisison to create and manage UI-Extensions (more information [here](https://api.akeneo.com/extensions/ui-extensions.html#prerequisites-2)).
+Having the proper permisison to create and manage UI-Extensions.
 
 ### Access the UI-extensions management Interface
 

--- a/content/graphql/limitations.md
+++ b/content/graphql/limitations.md
@@ -19,7 +19,7 @@ If you encounter any **challenges** with the `rate limits`, please don't hesitat
 
 Your insights are invaluable in fine-tuning our system for optimal performance.
 
-You can also find more details about the [REST API Limitations](/documentation/limitations.html)
+You can also find more details about the [REST API Good practices](/documentation/good-practices.html)
 :::
 The **GraphQL API** is limited to `500req/10s` per **PIM URL.**
 
@@ -136,7 +136,7 @@ If you encounter any **challenges** with the `depth limit`, please don't hesitat
 
 Your insights are invaluable in fine-tuning our system for optimal performance.
 
-You can also find more details about the [REST API Limitations](/documentation/limitations.html)
+You can also find more details about the [REST API Good practices](/documentation/good-practices.html)
 :::
 
 

--- a/tasks/copy-assets.js
+++ b/tasks/copy-assets.js
@@ -8,8 +8,23 @@ gulp.task('copy-assets', ['clean-dist'], function(){
     var fa = gulp.src(['node_modules/font-awesome/css/font-awesome.min.css',
             'node_modules/prismjs/themes/prism-okaidia.css'])
         .pipe(gulp.dest('dist/css/'));
-    var fonts = gulp.src('content/fonts/*')
-            .pipe(gulp.dest('dist/fonts/'));
+
+    var fonts = gulp.src([
+      'content/fonts/*',
+      'node_modules/font-awesome/fonts/*',
+      'node_modules/lato-font/fonts/lato-light/*',
+      'node_modules/lato-font/fonts/lato-light-italic/*',
+      'node_modules/lato-font/fonts/lato-normal/*',
+      'node_modules/lato-font/fonts/lato-normal-italic/*',
+      'node_modules/lato-font/fonts/lato-medium/*',
+      'node_modules/lato-font/fonts/lato-medium-italic/*',
+      'node_modules/lato-font/fonts/lato-semibold/*',
+      'node_modules/lato-font/fonts/lato-semibold-italic/*',
+      'node_modules/lato-font/fonts/lato-bold/*',
+      'node_modules/lato-font/fonts/lato-bold-italic/*',
+    ])
+        .pipe(gulp.dest('dist/fonts/'));
+
     var lib = gulp.src([
             'node_modules/jquery/dist/jquery.min.js',
             'node_modules/handlebars/handlebars.min.js',


### PR DESCRIPTION
Before this PR, when we deleted a page, the deletion was not propagated to the bucket that store the deployed files.
While adding the option that force the deletion of unmatching files, I restore some important files like fonts that are still used.