### PR TITLE
Added a new menu item for Activation

### DIFF
--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -241,6 +241,17 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                         </li>
                     </ul>
                 </li>
+                <li class="dropdown">
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Activation API<span class="caret"></span></a>
+                    <ul class="dropdown-menu">
+                        <li class="dropdown-title">Activation API resources</li>
+                        <li>
+                            <a href="https://api.retail.app.akeneo.cloud/">
+                            Activation API <span class="label label-beta">New</span>
+                            </a>
+                        </li>
+                    </ul>
+                </li>
 
                 <li class="dropdown{{#if active_guided_tutorials}} active{{/if}}">
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Guided tutorials <span class="caret"></span></a>


### PR DESCRIPTION
This is a very simple PR that adds a new link to the Activation API documentation. The change is made directly in the HTML.

Currently, the documentation is hard to find for internal employees and partners because it's on a different URL. This change, which was requested by our VP of Sales Engineering, will improve the documentation's discoverability.

I've attached a short video to show the change in action.

Video : https://www.loom.com/share/29b0d8f839b44d65ac5957924bf86e0c?sid=79f548aa-5f83-40e4-a49d-857a603cb9b6