### PR TITLE
Add fix for required properties in requestBody

### DIFF
--- a/content/img/illustrations/illus--Workflowexecutions.svg
+++ b/content/img/illustrations/illus--Workflowexecutions.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>

--- a/content/img/illustrations/illus--Workflowtasks.svg
+++ b/content/img/illustrations/illus--Workflowtasks.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="256" height="256"/>


### PR DESCRIPTION
This PR fixes an issue in the JS script that adapts the OpenAPI spec for documentation.
This allows the `required` properties of the schemas to be tagged in the documentation.
It also adds two empty icons for the section on workflows.