### PR TITLE
DXIM-446 - Update event format source to akeneo-event-platform

### DIFF
--- a/content/event-platform/best-practices.md
+++ b/content/event-platform/best-practices.md
@@ -17,7 +17,7 @@ Let's take an example:
 {
   "specversion": "1.0",
   "id": "018e197c-dfe2-70f8-9346-1a8e016f5fbb",
-  "source": "pim",
+  "source": "akeneo-event-platform",
   "type": "com.akeneo.pim.v1.product.updated",
   "subject": "0190fe8a-6213-76ce-8a9f-ba36a5ef555a",
   "datacontenttype": "application/json",

--- a/content/event-platform/concepts.md
+++ b/content/event-platform/concepts.md
@@ -388,7 +388,7 @@ Example of an event payload for a productDeleted event
 {
   "specversion": "1.0",
   "id": "018e197c-dfe2-70f8-9346-1a8e016f5fbb",
-  "source": "pim",
+  "source": "akeneo-event-platform",
   "type": "com.akeneo.pim.v1.product.deleted",
   "subject": "0190fe8a-6213-76ce-8a9f-ba36a5ef555a",
   "datacontenttype": "application/json",


### PR DESCRIPTION
## What
Update the `source` field in CloudEvents examples to reflect the actual value received by customers.

## Why
The documented `source` value (`pim`) does not match what customers actually receive (`akeneo-event-platform`), which can cause confusion when parsing or validating events.

## Changes
- Update `source` from `"pim"` to `"akeneo-event-platform"` in the event payload example in `content/event-platform/concepts.md`
- Update `source` from `"pim"` to `"akeneo-event-platform"` in the event payload example in `content/event-platform/best-practices.md`