### PR TITLE
TRUST-8: Add categories to the extensions grid action context

### DIFF
--- a/content/extensions/action.md
+++ b/content/extensions/action.md
@@ -8,6 +8,7 @@ Data sent within the POST body, formatted in JSON, contain:
 - A `context` object containing:
   - the configured `locale`,
   - the configured `channel`,
+  - the configured `categories` (only available for product grid actions).
 - A `user` object containing the `uuid`, `username` and `groups` of the connected user.
 - A `timestamp` that can be used with a [secret](#secret) to help you to protect your server against [replay attacks](https://en.wikipedia.org/wiki/Replay_attack).
 - A `data` object with different fields depending on the position:
@@ -30,7 +31,8 @@ Examples :
   },
   "context": {
     "locale": "en_US",
-    "channel": "ecommerce"
+    "channel": "ecommerce",
+    "categories": ["master_men_blazers_deals"]
   },
   "user": {
     "uuid": "e05cc457-b8ac-43b1-baa7-c4c112091ad8",


### PR DESCRIPTION
Add categories to the context sent on product grid actions

<img width="747" height="203" alt="image" src="https://github.com/user-attachments/assets/db7ba51c-59c7-4abd-985b-f8cc81a26538" />

It was formerly `category` but now that the new grid sends multiple categories, we now accept `categories`

cf old PR with category: https://github.com/akeneo/pim-api-docs/pull/1104