### PR TITLE
Document `symbol` field in metric attribute values

### DIFF
--- a/content/concepts/products.md
+++ b/content/concepts/products.md
@@ -61,7 +61,8 @@ Below is the JSON standard format representing a product.
         "scope": null,
         "data": {
           "amount": "800.0000",
-          "unit": "GRAM"
+          "unit": "GRAM",
+          "symbol": "g"
         }
       }
     ],
@@ -457,6 +458,7 @@ Whenever the attribute type is pim_catalog_product_link, the data field must con
 Whenever the attribute's type is `pim_catalog_metric`, the `data` field should contain an object with following fields:
 - `amount`: a string representing a number if the `decimals_allowed` property of the attribute is set to `true`, otherwise an integer, containing amount value
 - `unit`: a string representing the metric unit for the specified amount
+- `symbol`: a string representing the symbol of the unit (e.g. `g`, `kW`), resolved from the measurement family definition
 
 ##### Examples
 ```json
@@ -468,7 +470,8 @@ Whenever the attribute's type is `pim_catalog_metric`, the `data` field should c
         "scope": null,
         "data": {
           "amount":10,
-          "unit": "KILOWATT"
+          "unit": "KILOWATT",
+          "symbol": "kW"
         },
         "attribute_type": "pim_catalog_metric"
       }
@@ -485,7 +488,8 @@ Whenever the attribute's type is `pim_catalog_metric`, the `data` field should c
         "scope": null,
         "data": {
           "amount":"25.45",
-          "unit": "CENTIMETER"
+          "unit": "CENTIMETER",
+          "symbol": "cm"
         },
         "attribute_type": "pim_catalog_metric"
       }
@@ -1085,7 +1089,8 @@ Below is the JSON standard format representing a published product. Notice how t
         "scope": null,
         "data": {
           "amount": "600.0000",
-          "unit": "GRAM"
+          "unit": "GRAM",
+          "symbol": "g"
         }
       }
     ],

--- a/content/events-reference/events-reference-serenity/product-models.md
+++ b/content/events-reference/events-reference-serenity/product-models.md
@@ -71,7 +71,8 @@ A product model created event follows this format:
                                 "scope": null,
                                 "data": {
                                     "amount": "800.0000",
-                                    "unit": "GRAM"
+                                    "unit": "GRAM",
+                                    "symbol": "g"
                                 }
                             }
                         ],
@@ -189,7 +190,8 @@ A product model updated event follows this format:
                                 "scope": null,
                                 "data": {
                                     "amount": "800.0000",
-                                    "unit": "GRAM"
+                                    "unit": "GRAM",
+                                    "symbol": "g"
                                 }
                             }
                         ],

--- a/content/events-reference/events-reference-serenity/products.md
+++ b/content/events-reference/events-reference-serenity/products.md
@@ -72,7 +72,8 @@ A product created event follows this format:
                                 "scope": null,
                                 "data": {
                                     "amount": "800.0000",
-                                    "unit": "GRAM"
+                                    "unit": "GRAM",
+                                    "symbol": "g"
                                 }
                             }
                         ],
@@ -191,7 +192,8 @@ A product updated event follows this format:
                                 "scope": null,
                                 "data": {
                                     "amount": "800.0000",
-                                    "unit": "GRAM"
+                                    "unit": "GRAM",
+                                    "symbol": "g"
                                 }
                             }
                         ],


### PR DESCRIPTION
## Summary
- Adds a `symbol` bullet to the metric attribute `data` field reference in `content/concepts/products.md`
- Updates the 4 metric JSON examples in `content/concepts/products.md` and the 4 metric examples in the serenity events-reference (`products.md` + `product-models.md`) to include `"symbol": "<unit symbol>"`
- Reflects [akeneo/pim-enterprise-dev#37611](https://github.com/akeneo/pim-enterprise-dev/pull/37611), which exposes the unit symbol resolved from the measurement family definition in the standard normalizer output

## Scope
Limited to current/SaaS (serenity) documentation. Deliberately skipped:
- `events-reference-5.0/6.0/7.0/*` — released LTS versions where the field does not exist
- `content/getting-started/synchronize-pim-products-6x/step-4.md` — 6.x tutorial
- `content/misc/products-with-variants.md` — example is explicitly labeled "in 2.0"

## Test plan
- [ ] Visual review of the rendered docs preview for the metric attribute section
- [ ] Confirm the example JSON matches the actual API response on a SaaS environment
- [ ] Confirm with the PR author that `symbol` resolves to the value documented (e.g. `g` for `GRAM`, `kW` for `KILOWATT`, `cm` for `CENTIMETER`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)