### PR TITLE
Remove MCP Beta tag from the menu

### DIFF
--- a/src/partials/layout.handlebars
+++ b/src/partials/layout.handlebars
@@ -191,7 +191,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
                         </li>
                         <li>
                             <a href="/mcp/overview.html">
-                                MCP <span class="label label-beta">Beta</span>
+                                MCP
                             </a>
                         </li>
                         <li>


### PR DESCRIPTION
Akeneo's MCP server is full GA, the Beta tag is not relevant anymore