### PR TITLE
DXIM-623: document stripped request headers in SDK external calls

### DIFF
--- a/content/advanced-extensions/sdk-in-depth.md
+++ b/content/advanced-extensions/sdk-in-depth.md
@@ -251,7 +251,8 @@ const response = await PIM.api.external.call({
   method: 'GET',
   url: 'https://api.example.com/data',
   headers: {
-    'Content-Type': 'application/json'
+    'Accept': 'application/json',
+    'X-Custom-Header': 'my-value'
   }
 });
 
@@ -259,15 +260,16 @@ const response = await PIM.api.external.call({
 const createResponse = await PIM.api.external.call({
   method: 'POST',
   url: 'https://api.example.com/items',
-  headers: {
-    'Content-Type': 'application/json'
-  },
   body: JSON.stringify({
     name: 'New Item',
     description: 'Item description'
   })
 });
 ```
+
+::: warning
+For security reasons, some request headers are stripped before the request is forwarded and cannot be overridden. This includes `Content-Type`, along with sensitive or hop-by-hop headers such as `Host`, `Authorization`, `Cookie` and `X-Forwarded-*`. The request body is currently sent with a default `Content-Type: application/json`; custom content types such as `application/x-www-form-urlencoded` are not supported at this time. For authentication, use the `credentials_code` parameter instead of setting an `Authorization` header.
+:::
 
 ### Authenticated Calls
 
@@ -290,6 +292,7 @@ const secureResponse = await PIM.api.external.call({
 
 - This is the **only method** allowed for accessing external resources from your extension
 - For security reasons, requests are proxied through the PIM server
+- For security reasons, some request headers (including `Content-Type`) are stripped and cannot be overridden; the body is sent with a default `Content-Type: application/json`
 - The method supports standard HTTP methods (GET, POST, PUT, DELETE, etc.)
 - Responses are returned as promises that can be handled with async/await
 


### PR DESCRIPTION
## What

The External API Calls section of the SDK in-depth guide showed a
`Content-Type` header in its examples, implying callers can set request
headers freely. In practice, `PIM.api.external.call` strips a deny-list of
headers (including `Content-Type`) for security, and applies a default
`Content-Type: application/json`.

## Change

- Removed the misleading `Content-Type` header from the examples (replaced
  the GET example with headers that are actually forwarded).
- Added a warning callout listing the stripped headers, the default
  Content-Type, and pointing to `credentials_code` for authentication.
- Added a matching bullet in "Important Considerations".

Reported via customer requests where a custom `Content-Type`
(e.g. `application/x-www-form-urlencoded` for OAuth2 client_credentials)
did not take effect.
