### PR TITLE
docs(advanced-extensions): document PIM context postMessage for custom components

### DIFF
--- a/content/advanced-extensions/sdk-in-depth.md
+++ b/content/advanced-extensions/sdk-in-depth.md
@@ -194,6 +194,53 @@ if ('product' in PIM.context) {
 }
 ```
 
+## PIM context changes
+
+`PIM.context` and `PIM.user` are a snapshot taken when your component loads. To keep track of the **locale** or **channel** currently selected by the user, listen for [PostMessage](https://developer.mozilla.org/docs/Web/API/Window/postMessage) events — the same mechanism used by iframe extensions.
+
+The PIM sends this message when your component loads, and again whenever the user changes locale or channel:
+
+```json
+{
+  "context": {
+    "locale": "en_US",
+    "channel": "ecommerce"
+  },
+  "user": {
+    "uuid": "c71228d3-695c-4ded-8f3d-b3ed881a1f59",
+    "username": "admin",
+    "groups": [
+      {"id": 8, "name": "IT support"},
+      {"id": 11, "name": "All"}
+    ]
+  }
+}
+```
+
+Listen for it with:
+
+```js
+window.addEventListener('message', event => {
+  if (event.data?.context) {
+    const {locale, channel} = event.data.context;
+    // React to the new locale/channel
+  }
+});
+```
+
+### Requesting context on demand
+
+In modern JavaScript frameworks like React, components may initialize after the initial context message was already sent, causing them to miss it. In that case, request it explicitly:
+
+```js
+window.parent.postMessage(
+  {
+    type: 'request_context'
+  },
+  '*'
+);
+```
+
 ## Navigation within the PIM
 
 The SDK  navigation method that allows you to open new tabs. This is useful for directing users to different sections of the PIM from your extension:

--- a/content/extensions/iframe.md
+++ b/content/extensions/iframe.md
@@ -94,7 +94,7 @@ Example :
 
 ### Product, product model and reference entity record context change
 
-When the user changes the **PIM context** (such as selecting a different **locale** or **channel**), these changes are automatically propagated to the iframe via PostMessage.
+When the user changes the **PIM context** (such as selecting a different **locale** or **channel**), these changes are automatically propagated to the iframe via PostMessage. This same message is also sent once when the iframe first loads.
 
 The message contains :
 - A `context` object containing the selected `locale` and `channel`.


### PR DESCRIPTION
## Summary
- Add a "PIM context changes" section to `advanced-extensions/sdk-in-depth.md` documenting the postMessage mechanism custom components can use to track the currently selected locale/channel (load, on-change, and on-demand via `request_context`), mirroring the existing iframe docs.
- Note in `extensions/iframe.md` that the context message is also sent once when the iframe first loads.

Documents [DXIM-694](https://akeneo.atlassian.net/browse/DXIM-694) / [SDS-56211](https://akeneo.atlassian.net/browse/SDS-56211), implemented in [pim-enterprise-dev#39480](https://github.com/akeneo/pim-enterprise-dev/pull/39480).

## Test plan
- [ ] Build the docs site (`make serve`) and check `/advanced-extensions/sdk-in-depth.html` and `/extensions/iframe.html` render correctly with the new section in the left TOC

[DXIM-694]: https://akeneo.atlassian.net/browse/DXIM-694?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDS-56211]: https://akeneo.atlassian.net/browse/SDS-56211?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ