### PR TITLE
Soften MCP availability language in Before You Start

### DIFF
--- a/content/mcp/getting-started.md
+++ b/content/mcp/getting-started.md
@@ -5,7 +5,7 @@ This guide provides step-by-step instructions to connect your Akeneo PIM to AI-p
 ## Before You Start
 
 ::: info
-Note: Akeneo MCP may require additional commercial activation depending on your package. Contact your Akeneo Customer Success Manager (CSM) for more details. Share your use cases with us here - [MCP Use Cases](https://forms.gle/UXuL5PkHnj3JkRke7).
+Availability may vary based on your Akeneo package. If you have any questions, contact your Akeneo Customer Success Manager (CSM). We'd also love to hear about your use cases [here](https://forms.gle/UXuL5PkHnj3JkRke7).
 :::
 
 ### Permissions and Governance


### PR DESCRIPTION
## What

Reword the **Before You Start** disclaimer on the MCP Getting Started page.

**Before:**
> Note: Akeneo MCP may require additional commercial activation depending on your package. Contact your Akeneo Customer Success Manager (CSM) for more details. Share your use cases with us here - [MCP Use Cases](...).

**After:**
> Availability may vary based on your Akeneo package. If you have any questions, contact your Akeneo Customer Success Manager (CSM). We'd also love to hear about your use cases [here](...).

The use-cases link is unchanged (`https://forms.gle/UXuL5PkHnj3JkRke7`).

## Why

All customers are currently whitelisted for the MCP free trial, so the previous "may require additional commercial activation" wording was confusing partners and customers during the trial period (the message persists past the trial). Product/CS asked to soften the language: still route customers to their CSM for availability questions, while keeping the invitation to share use cases.

This wording was agreed in a CS/product thread; the "Availability may vary based on your Akeneo package..." phrasing is the approved suggestion from that discussion.

Page: https://api.akeneo.com/mcp/getting-started.html#before-you-start

🤖 Generated with [Claude Code](https://claude.com/claude-code)