### PR TITLE
[Event Platform] Document error_code for Pub/Sub and Kafka destinations

### DIFF
--- a/content/event-platform/logs.md
+++ b/content/event-platform/logs.md
@@ -26,7 +26,7 @@ Logs provide detailed insights into system events, which can be categorized as *
 | `operation`         | String      | Describes the operation or event related to the log (e.g., event delivery failure).              | `failed_to_deliver_event`                     |
 | `error_type`        | String      | Indicates the specific type of error, if the log represents an error.                            | `validation_error`                            |
 | `error_reason`      | String      | Stable, machine-readable cause of a delivery failure (delivery error logs only). Drawn from a fixed set of values and safe to filter on, unlike the free-text `error_message`. | `connection_refused`                          |
-| `error_code`        | Integer     | The HTTP status code or application-specific error code associated with the error (if present).  | `400`                                         |
+| `error_code`        | Integer     | The error code associated with the error (if present). For HTTPS destinations, this is the HTTP status code returned by your endpoint. For destinations that are not reached over HTTP, such as Pub/Sub and Kafka, no HTTP exchange takes place and this value is an internal transport code that carries no meaning outside the platform: use `error_reason` to identify the cause. | `400`                                         |
 | `error_message`     | String      | A detailed message describing the error, helpful for diagnosing issues.                          | `Invalid request`                             |
 | `request`           | Object      | Represents the HTTP request data related to the log, if applicable.                              | `{ "url": "/api/v1/events", "method": "POST" }` |
 | `response`          | Object      | Represents the HTTP response data related to the log, if applicable.                             | `{ "status": 500, "body": "Internal Server Error" }` |
@@ -102,6 +102,25 @@ An error occurs when trying to deliver an event, possibly due to a timeout or an
 ```
 
 When filtering or alerting on delivery failures, prefer `error_reason` over `error_code` and `error_message`. The latter two can be generic: a transport failure (timeout, DNS, TLS, connection refused, ...) is reported with a `500` error code and a free-text message, which does not tell the failures apart. `error_reason` is drawn from a fixed set of values, so it is stable and safe to filter on.
+
+This matters even more for destinations that are not reached over HTTP, such as Pub/Sub and Kafka. No HTTP request is made to those destinations, so `error_code` holds an internal transport code rather than a status returned by your system, and it should not be interpreted as one. Below, a Kafka subscription whose credentials were rejected: the cause is only readable in `error_reason`.
+
+```json
+{
+  "log_id": "019362ca-c547-7364-9274-8d3cf7c3d130",
+  "log_type": "error",
+  "timestamp": "2024-11-25T10:07:56Z",
+  "operation": "failed_to_deliver_event",
+  "subscriber_id": "019363c4-6e22-7dd4-a811-6aab07f1d474",
+  "subscription_id": "01934a2c-1491-7bea-bced-5176bf92ff3c",
+  "error_type": "failed_delivery",
+  "error_reason": "authentication_failed",
+  "error_code": 404,
+  "error_message": "authentication was rejected by the destination",
+  "request": {},
+  "response": {}
+}
+```
 
 ### Notes on Logs
 Logs are only available for a rolling window of 30 days. Ensure you retrieve any required log data within this period to avoid losing critical information.


### PR DESCRIPTION
Companion doc PR for https://github.com/akeneo/event-platform/pull/781 (DXIM-749).

For destinations that are not reached over HTTP (Pub/Sub, Kafka), no HTTP exchange takes place, yet `error_code` carries an HTTP-shaped value. Readers currently interpret it as a status returned by their system, which it is not.

This documents `error_code` as an internal transport code for those destinations, and points to `error_reason` as the field that actually carries the cause. Adds a Kafka example where credentials were rejected.

The list of `error_reason` values is deliberately not duplicated here: the OpenAPI specification linked at the top of the page stays the source of truth.

Draft on purpose: must not be merged before event-platform#781 ships, otherwise it documents values that do not exist in production yet.