### PR TITLE
Update Event Platform filter max operators limit from 4 to 10

### DIFF
--- a/content/event-platform/available-filters.md
+++ b/content/event-platform/available-filters.md
@@ -167,7 +167,7 @@ and makes the filter more readable.
 |--------------------------|----------------|------------------------------------------------|
 | Filters per subscription | 1              | Only one filter expression per subscription    |
 | Maximum length           | 500 characters | Total length of filter expression              |
-| Maximum operators        | 4              | Number of logical operators in a single filter |
+| Maximum operators        | 10             | Number of logical operators in a single filter |
 
 ### Syntax Rules
 


### PR DESCRIPTION
## What

Updates the Event Platform filter constraints documentation: the maximum number of logical operators in a single filter expression is now **10** (previously 4), following the corresponding change on the Event Platform side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)