### PR TITLE
[Event Platform] Document what to check for each delivery failure cause

### DIFF
--- a/content/event-platform/logs.md
+++ b/content/event-platform/logs.md
@@ -28,6 +28,7 @@ Logs provide detailed insights into system events, which can be categorized as *
 | `error_reason`      | String      | Stable, machine-readable cause of a delivery failure (delivery error logs only). Drawn from a fixed set of values and safe to filter on, unlike the free-text `error_message`. | `connection_refused`                          |
 | `error_code`        | Integer     | The error code associated with the error (if present). For HTTPS destinations, this is the HTTP status code returned by your endpoint. For destinations that are not reached over HTTP, such as Pub/Sub, Kafka, and AMQP 1.0, no HTTP exchange takes place and this value is an internal transport code that carries no meaning outside the platform: use `error_reason` to identify the cause. | `400`                                         |
 | `error_message`     | String      | A detailed message describing the error, helpful for diagnosing issues.                          | `Invalid request`                             |
+| `documentation_url` | String      | Link to the section of this page explaining the cause reported in `error_reason` and what to check. Present on delivery error logs. | `https://api.akeneo.com/event-platform/logs.html#connection_refused` |
 | `request`           | Object      | Represents the HTTP request data related to the log, if applicable.                              | `{ "url": "/api/v1/events", "method": "POST" }` |
 | `response`          | Object      | Represents the HTTP response data related to the log, if applicable.                             | `{ "status": 500, "body": "Internal Server Error" }` |
 
@@ -121,6 +122,114 @@ This matters even more for destinations that are not reached over HTTP, such as 
   "response": {}
 }
 ```
+
+### Delivery Failure Causes
+
+Every delivery error log carries an `error_reason` and a `documentation_url` pointing at the matching section below. Each one tells you what the platform observed and what to check on your side.
+
+Unless stated otherwise, the platform retries the delivery: a failure does not mean the event is lost.
+
+#### destination_timeout
+
+Your endpoint accepted the connection but did not answer in time.
+
+Acknowledge the event first and process it asynchronously. An endpoint that does its own work before responding will time out again as soon as your volume grows.
+
+#### dns_lookup_failure
+
+The domain name of your endpoint could not be resolved.
+
+Check that the domain still exists, that it resolves publicly and not only inside your own network, and that a recent DNS change has propagated.
+
+#### invalid_certificate
+
+The TLS certificate presented by your endpoint was rejected.
+
+Check its expiry date and that the intermediate certificates are served alongside it. A certificate valid in a browser can still be rejected here, because browsers carry intermediates that a server-to-server client does not.
+
+#### invalid_tls_handshake
+
+The TLS negotiation failed before any request was sent.
+
+Check the TLS versions and cipher suites your endpoint accepts. This also happens when the address answers in plain HTTP while the subscription is configured in HTTPS.
+
+#### connection_reset
+
+Your endpoint closed the connection while the request was in flight.
+
+Look at what sits in front of your application: a proxy, a load balancer or a firewall dropping connections that exceed a size or duration limit is the usual cause.
+
+#### connection_refused
+
+Nothing accepted the connection on the target port.
+
+Check that your service is running and listening on the port of the configured URL, and that no firewall rejects our calls.
+
+#### network_unreachable
+
+No network route to your endpoint.
+
+Check that the address is reachable from the public internet. An address that only resolves inside a private network cannot be reached.
+
+#### unexpected_eof
+
+Your endpoint closed the connection without answering.
+
+Often the sign of a crash while processing the event, or of a component in front closing idle connections too aggressively.
+
+#### server_goaway
+
+Your endpoint asked to close the HTTP/2 connection while the request was being sent.
+
+Check the connection limits of your HTTP/2 server, in particular the maximum number of requests or the maximum lifetime of a connection.
+
+#### client_closed_connection
+
+The connection was closed before the exchange completed.
+
+Same checks as `unexpected_eof`: stability of your endpoint and the timeouts of whatever sits in front of it.
+
+#### destination_not_found
+
+Your destination reported that the target does not exist, and the subscription was suspended.
+
+For an HTTPS subscription, check that the URL is complete and still routed. For Pub/Sub or Kafka, check that the topic and the project exist. Fix the configuration, then resume the subscription.
+
+#### destination_redirected
+
+Your endpoint answered with a redirection, and the subscription was suspended.
+
+The platform does not follow redirects, because a redirect can silently send your events elsewhere. Configure the final URL directly, then resume the subscription.
+
+#### authentication_failed
+
+Your destination rejected the credentials.
+
+Check the credentials configured on the subscription and whether they were rotated on your side. On Kafka, also check the SASL mechanism.
+
+#### topic_not_found
+
+The target topic does not exist, and the subscription was suspended.
+
+Check the topic name and the project or cluster it belongs to. Create it or fix the configuration, then resume the subscription.
+
+#### invalid_destination_configuration
+
+The destination could not be initialised from the configuration of the subscription.
+
+Check the configuration as a whole: broker address, security settings, and for Kafka the TLS material. This is a configuration problem, not a transient failure.
+
+#### publish_rejected
+
+Your broker refused to accept the message.
+
+Check the quotas, the maximum message size and the write permissions of the account used by the subscription.
+
+#### destination_failure
+
+Your destination answered with an error the platform cannot attribute to a more precise cause. This is the catch-all.
+
+Read `error_code` and `error_message` on the log, and `response` when present, which carries the body your own system returned.
 
 ### Notes on Logs
 Logs are only available for a rolling window of 30 days. Ensure you retrieve any required log data within this period to avoid losing critical information.


### PR DESCRIPTION
https://akeneo.atlassian.net/browse/DXIM-752

Companion of the event-platform PR that fills `documentation_url` on delivery error logs. **Merge this one first**: the links ship pointing at these anchors, so the page must be online before the platform starts returning them.

## What

Adds a **Delivery Failure Causes** section to the logs page, with one section per `error_reason` value. Each one says what the platform observed and what to check.

Section titles are the `error_reason` value verbatim, so a client reading `"error_reason": "invalid_certificate"` in a log lands on a heading with the same text.

Also adds `documentation_url` to the log fields table.

## Coverage

All 17 values of the contract, not only the frequent ones. A rare cause like `server_goaway` or `invalid_tls_handshake` is exactly the one nobody recognises, and production measurements show the long tail is small but real.

The four causes that suspend the subscription say so and remind the reader to resume it once fixed. An introductory line states that every other cause is retried, so a failure does not mean a lost event.

## Anchors

Checked against the real generator rather than assumed. `markdown-it-toc-and-anchor` uses `uslug`, which keeps underscores, so `#### destination_timeout` yields `#destination_timeout`. Cross-checked the 17 URLs hardcoded on the platform side against the anchors this page actually produces: no mismatch.

This is the one thing that would have broken all 17 links silently, with no error anywhere.
