### PR TITLE
DXIM - fix OAuth2 scope and external call Content-Type doc

### DIFF
--- a/content/advanced-extensions/sdk-credentials.md
+++ b/content/advanced-extensions/sdk-credentials.md
@@ -13,7 +13,7 @@ Credentials allow your Extensions to make authenticated calls to external APIs a
 | Custom Header        | `{custom_header_key}: {custom_header_value}`       | Custom authentication schemes |
 | OAuth2               | `Authorization: Bearer {fetched_access_token}`     | APIs requiring a short-lived token obtained from a token endpoint |
 
-With the first three methods, you store the exact value that is sent in the header. With **OAuth2**, you store the details of a token endpoint instead, and the PIM obtains the access token for you on each call. See [OAuth2 Credentials](#oauth2-credentials).
+With the first three methods, you store the exact value that is sent in the header. With **OAuth2**, you store the details of a token endpoint instead, and the PIM obtains the access token for you on each call. OAuth2 is specific to Custom Components, see [OAuth2 Credentials](#oauth2-credentials).
 
 ## Configuring Credentials
 
@@ -51,7 +51,7 @@ curl --location '{YOUR_PIM_HOST}/api/rest/v1/ui-extensions' \
 Many APIs do not accept a long-lived token. They expose a token endpoint, and expect you to exchange client credentials for a short-lived access token before every call. The OAuth2 credential type lets the PIM perform that exchange server-side, so your extension code never fetches, stores or refreshes a token itself.
 
 ::: warning
-OAuth2 credentials are only used by `PIM.api.external.call()` in a Custom Component extension. An OAuth2 credential configured on an **Action** or a **Data Component** extension is ignored, and the request is sent without an authentication header.
+OAuth2 is only available on Custom Component extensions, where the token is used by `PIM.api.external.call()`. The other extension types, **Action**, **Link**, **Iframe** and **Data Component**, do not support it: the PIM does not offer the OAuth2 method when you configure their credentials, and a request sending one through the API is rejected with a validation error. Use Bearer Token, Basic Authentication or a Custom Header for those.
 :::
 
 ### Grant Types
@@ -72,7 +72,7 @@ Two grant types are available, selected with the **Grant Type** field:
 | `client_secret` | Yes      | The client secret |
 | `scope`         | No       | The requested scope, if your provider expects one |
 | `audience`      | No       | The requested audience, expected by some providers such as Auth0 |
-| `header_name`   | No       | The header used to send the access token, see [Sending the Access Token Under a Custom Header](#sending-the-access-token-under-a-custom-header) |
+| `header_name`   | No       | The header used to send the access token. Defaults to `Authorization`, with the token sent as `Bearer {access_token}`. Under any other header name, for example `X-PIM-TOKEN`, the raw token is sent without the `Bearer` prefix |
 
 [![oauth2-credential-client-credentials.png](../../img/extensions/ui-extensions/oauth2-credential-client-credentials.png)](../../img/extensions/ui-extensions/oauth2-credential-client-credentials.png)
 
@@ -106,7 +106,7 @@ Unlike the other credential types, whose `value` is a single string, an OAuth2 `
 | `username`      | Yes      | The username of the account used to authenticate |
 | `password`      | Yes      | The password of that account |
 | `scope`         | No       | The requested scope, if the token endpoint expects one |
-| `header_name`   | No       | The header used to send the access token, see [Sending the Access Token Under a Custom Header](#sending-the-access-token-under-a-custom-header) |
+| `header_name`   | No       | The header used to send the access token. Defaults to `Authorization`, with the token sent as `Bearer {access_token}`. Under any other header name, for example `X-PIM-TOKEN`, the raw token is sent without the `Bearer` prefix |
 
 [![oauth2-credential-password-grant.png](../../img/extensions/ui-extensions/oauth2-credential-password-grant.png)](../../img/extensions/ui-extensions/oauth2-credential-password-grant.png)
 
@@ -115,14 +115,6 @@ The PIM sends `grant_type=password` to the token endpoint, with the username and
 ::: warning
 Use a dedicated API user for this connection rather than a personal account, since its username and password are stored to authenticate the connection. If the account is disabled or its password is rotated, every external call using this credential starts failing.
 :::
-
-### Sending the Access Token Under a Custom Header
-
-By default, the access token is sent as `Authorization: Bearer {access_token}`. Some APIs expect it under a different header instead. Set the optional `header_name` field to that header name, for example `X-PIM-TOKEN`, and the raw access token is sent under it, without the `Bearer` prefix:
-
-```
-X-PIM-TOKEN: {access_token}
-```
 
 ### Token Lifecycle
 

--- a/content/advanced-extensions/sdk-in-depth.md
+++ b/content/advanced-extensions/sdk-in-depth.md
@@ -320,8 +320,35 @@ const createResponse = await PIM.api.external.call({
 ```
 
 ::: warning
-For security reasons, some request headers are stripped before the request is forwarded and cannot be overridden. This includes `Content-Type`, along with sensitive or hop-by-hop headers such as `Host`, `Authorization`, `Cookie` and `X-Forwarded-*`. The request body is currently sent with a default `Content-Type: application/json`; custom content types such as `application/x-www-form-urlencoded` are not supported at this time. For authentication, use the `credentials_code` parameter instead of setting an `Authorization` header.
+For security reasons, sensitive and hop-by-hop headers such as `Host`, `Authorization`, `Cookie`, `Content-Length` and `X-Forwarded-*` are stripped before the request is forwarded, and cannot be overridden. For authentication, use the `credentials_code` parameter instead of setting an `Authorization` header.
 :::
+
+### Request Content Type
+
+The request body is sent with `Content-Type: application/json` by default. To send something else, set the `Content-Type` header on the call. Three content types are accepted:
+
+- `application/json`
+- `application/x-www-form-urlencoded`
+- `text/plain`
+
+Any other value is discarded and the default `application/json` applies. Parameters are preserved, so `application/json; charset=utf-8` is forwarded as you wrote it.
+
+```js
+// Send a form-encoded body
+const response = await PIM.api.external.call({
+  method: 'POST',
+  url: 'https://api.example.com/token',
+  headers: {
+    'Content-Type': 'application/x-www-form-urlencoded'
+  },
+  body: {
+    grant_type: 'client_credentials',
+    scope: 'products:read'
+  }
+});
+```
+
+When `body` is an object and the content type is `application/x-www-form-urlencoded`, the PIM URL-encodes it for you. When `body` is a string, it is forwarded as-is under the declared content type, which is what you need for `text/plain` or for a payload you have already serialized yourself.
 
 ### Authenticated Calls
 
@@ -346,7 +373,7 @@ The referenced credential can be a Bearer token, Basic authentication, a custom 
 
 - This is the **only method** allowed for accessing external resources from your extension
 - For security reasons, requests are proxied through the PIM server
-- For security reasons, some request headers (including `Content-Type`) are stripped and cannot be overridden; the body is sent with a default `Content-Type: application/json`
+- For security reasons, sensitive and hop-by-hop headers are stripped and cannot be overridden; the body is sent with a default `Content-Type: application/json`, which you can override with one of the accepted content types
 - The method supports standard HTTP methods (GET, POST, PUT, DELETE, etc.)
 - Responses are returned as promises that can be handled with async/await
 

--- a/content/extensions/credentials.md
+++ b/content/extensions/credentials.md
@@ -8,22 +8,11 @@ You have the ability to make authenticated calls via Extensions using credential
 | Basic Authentication | `Authorization : base64_encode(username:password)` |    
 | Bearer Token         | `Authorization : Bearer token_value`               |
 | Custom Credentials   | `custom_header_key : custom_header_value`          |
-| OAuth2               | `Authorization : Bearer fetched_access_token`      |
 
 To add credentials, simply select your preferred authentication method and enter the required information.
 [![basic-auth-credential.png](../../img/extensions/ui-extensions/basic-auth-credential.png)](../../img/extensions/ui-extensions/basic-auth-credential.png)
 
 Credentials are encrypted before being stored, ensuring the security of your sensitive data. Additionally, the API calls are made server-side, meaning that the credentials are not accessible from the front end of the application.
-
-### About OAuth2
-
-With the first three methods, you provide the value that is sent in the header. With **OAuth2**, you provide the details of a token endpoint instead: the PIM requests an access token from that endpoint server-side, then sends it in the request. Your extension never handles the token itself.
-
-::: warning
-OAuth2 credentials are only used by the `PIM.api.external.call()` method of a Custom Component extension. An OAuth2 credential configured on an **Action** or a **Data Component** extension is ignored, and the request is sent without any authentication header. For those extension types, use Basic Authentication, Bearer Token or Custom Credentials.
-:::
-
-For the available grant types, the required fields and the complete configuration reference, see the [Credentials guide for Custom Components](/advanced-extensions/sdk-credentials.html).
 
 ::: panel-link Filtering [Next](/extensions/filtering.html)
 :::


### PR DESCRIPTION
Follow-up on three review remarks on the Custom Component documentation.

## OAuth2 is not available on basic extensions

`content/extensions/credentials.md` advertised OAuth2, but no basic extension supports it. `ExtensionType::supportsOAuth2Credentials()` returns true only for `sdk_script`, and not for the `external_data_source` subtype, so:

- `GetAvailableTypeOfAuthController` never offers OAuth2 for Action, Link, Iframe or Data Component extensions,
- `OAuth2ShouldBeSupportedByExtensionTypeValidator` rejects one sent through the API with a validation error.

The credential row and the `About OAuth2` section are removed from that page. The Custom Component page claimed such a credential was *ignored, and the request is sent without an authentication header*, which was wrong too: it never gets saved in the first place. Rewritten accordingly.

## Content-Type on `PIM.api.external.call()`

The docs still said `Content-Type` is stripped and that *custom content types such as `application/x-www-form-urlencoded` are not supported at this time*. That shipped since. `ExtensionHttpClient` now reads the caller's `Content-Type` and honours it when its base type is one of `application/json`, `application/x-www-form-urlencoded` or `text/plain`, keeping parameters such as `; charset=utf-8` and falling back to `application/json` otherwise. An object body sent as form-urlencoded is URL-encoded by the PIM, a string body is forwarded as-is.

`sdk-in-depth.md` gets a `Request Content Type` section with the accepted values and a form-encoded example, and the warning no longer lists `Content-Type` among the stripped headers.

## Custom access token header

`Sending the Access Token Under a Custom Header` was a section for a single optional field, sitting between the grant types and the token lifecycle. Its content moves into the `header_name` row of both OAuth2 field tables, which already linked to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)